### PR TITLE
chore: basic decorateIcons parallel test

### DIFF
--- a/test/decorate/decorateIcons.parallel.test.html
+++ b/test/decorate/decorateIcons.parallel.test.html
@@ -28,13 +28,8 @@
         expect(icons.length).to.equal(2);
         icons.forEach((icon) => {
           expect(icon.childElementCount).to.be.equal(1);
-          const svg = icon.firstElementChild;
-          expect(svg.tagName).to.be.equal('svg');
-          if (svg.childElementCount === 1 && svg.firstElementChild.tagName === 'use') {
-            const href = icon.firstElementChild.firstElementChild.getAttribute('href');
-            const sprite = document.querySelector(`#franklin-svg-sprite > ${href}`);
-            expect(sprite).to.not.be.null;
-          }
+          expect(icon.firstElementChild.tagName).to.be.equal('IMG');
+          expect(icon.firstElementChild.loading).to.be.equal('lazy');
         });
       });
     });


### PR DESCRIPTION
This is a basic test for https://github.com/adobe/helix-project-boilerplate/pull/256 - i.e., a **styled** icon gets loaded in parallel (two promises race to decorateIcons the same icon). With the current boilerplate, this fails pretty reliable - hence, this test should fail (at least most of the time) until it is fixed.  
 