### PR TITLE
Issue 13 - SVG icons adding aria-lable to improve lighthouse score

### DIFF
--- a/src/decorate.js
+++ b/src/decorate.js
@@ -102,7 +102,14 @@ export async function decorateIcons(element) {
 
   icons.forEach((span) => {
     const iconName = Array.from(span.classList).find((c) => c.startsWith('icon-')).substring(5);
-    const parent = span.firstElementChild?.tagName === 'A' ? span.firstElementChild : span;
+    let parent;
+    if (span.firstElementChild?.tagName === 'A') {
+      parent = span.firstElementChild;
+      parent.setAttribute('aria-label', iconName);
+    } else {
+      parent = span;
+      if (parent.parentNode.tagName === 'A') parent.parentNode.setAttribute('aria-label', iconName);
+    }
     // Styled icons need to be inlined as-is, while unstyled ones can leverage the sprite
     if (ICONS_CACHE[iconName].styled) {
       parent.innerHTML = ICONS_CACHE[iconName].html;


### PR DESCRIPTION
## When an author links a :svg-icon: (common use case for the brand logo in the header), the resulting HTML is an A tag without textual content or an aria-label, which incurs a lighthouse accessibility ding.  

Modified the decorateIcons() function to add an aria-lable attribute with the icon name to the parent A tag when it exist.

## 13

https://github.com/adobe/aem-lib/issues/13

## Motivation and Context

Fixes accessibility issue impacting lighthouse score

## How Has This Been Tested?

Add a SVG :icon-name: to a document and then hyperlink it.  Preview the page and run a lighthouse scan with accessibility checked.  You will see that there is an issue present. 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
