### PR TITLE
feat: enable getMetadata to query any document

### DIFF
--- a/src/dom-utils.js
+++ b/src/dom-utils.js
@@ -42,7 +42,7 @@ export async function loadScript(src, attrs) {
       const script = document.createElement('script');
       script.src = src;
       if (attrs) {
-      // eslint-disable-next-line no-restricted-syntax, guard-for-in
+        // eslint-disable-next-line no-restricted-syntax, guard-for-in
         for (const attr in attrs) {
           script.setAttribute(attr, attrs[attr]);
         }
@@ -59,11 +59,12 @@ export async function loadScript(src, attrs) {
 /**
  * Retrieves the content of metadata tags.
  * @param {string} name The metadata name (or property)
+ * @param {Document} doc Document object to query for metadata. Defaults to the window's document
  * @returns {string} The metadata value(s)
  */
-export function getMetadata(name) {
+export function getMetadata(name, doc = document) {
   const attr = name && name.includes(':') ? 'property' : 'name';
-  const meta = [...document.head.querySelectorAll(`meta[${attr}="${name}"]`)].map((m) => m.content).join(', ');
+  const meta = [...doc.head.querySelectorAll(`meta[${attr}="${name}"]`)].map((m) => m.content).join(', ');
   return meta || '';
 }
 

--- a/test/dom-utils/getMetadata.test.html
+++ b/test/dom-utils/getMetadata.test.html
@@ -30,6 +30,30 @@
         it('get article:tag', () => {
           expect(getMetadata('article:tag')).to.equal('tag 1, tag 2, tag 3');
         });
+
+        // Test a custom document
+        const testDoc = document.implementation.createHTMLDocument();
+        const titleMeta = testDoc.createElement('meta');
+        titleMeta.setAttribute('property', 'og:title');
+        titleMeta.setAttribute('content', 'Camping in Western Australia');
+        testDoc.head.appendChild(titleMeta);
+
+        const descriptionMeta = testDoc.createElement('meta');
+        descriptionMeta.setAttribute('property', 'og:description');
+        descriptionMeta.setAttribute('content', 'The Australian West coast is a camper’s heaven.');
+        testDoc.head.appendChild(descriptionMeta);
+
+        it('get og:title from custom document', () => {
+          expect(getMetadata('og:title', testDoc)).to.equal('Camping in Western Australia');
+        });
+
+        it('get og:description from custom document', () => {
+          expect(getMetadata('og:description', testDoc)).to.equal('The Australian West coast is a camper’s heaven.');
+        });
+
+        it('query metadata which does not exist from custom document', () => {
+          expect(getMetadata('og:not-set-metadata', testDoc)).to.equal('');
+        });
       });
     </script>
   </body>


### PR DESCRIPTION
## Description

Add an optional param to the `getMetadata` function to enable any document to be queried.

## Related Issue

Relates to an PR discussion & issue on the WKND repo: https://github.com/hlxsites/wknd/pull/40

## How Has This Been Tested?

Added unit tests.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
