### PR TITLE
build(package): release aem.js to npmjs.com

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "@adobe/aem-lib",
-  "private": true,
   "version": "1.3.2",
   "description": "AEM Library",
   "type": "module",


### PR DESCRIPTION
It looks like our release process isn't running smooth yet, the release to npm is skipped, because the package was marked as private.