### PR TITLE
feat: add minimal plugin system

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -24,7 +24,8 @@ const banner = `/*
  * OF ANY KIND, either express or implied. See the License for the specific language
  * governing permissions and limitations under the License.
  */
-`;
+
+/* eslint-disable max-classes-per-file */`;
 
 const bundles = [
   {

--- a/src/block-loader.js
+++ b/src/block-loader.js
@@ -95,7 +95,7 @@ export async function loadBlock(block) {
     block.dataset.blockStatus = 'loading';
     const { blockName, cssPath, jsPath } = getBlockConfig(block);
     try {
-      await loadModule(blockName, jsPath, cssPath, block);
+      await loadModule(jsPath, cssPath, block);
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log(`failed to load block ${blockName}`, error);

--- a/src/dom-utils.js
+++ b/src/dom-utils.js
@@ -58,15 +58,14 @@ export async function loadScript(src, attrs) {
 
 /**
  * Loads JS and CSS for a module and executes it's default export.
- * @param {string} name The module name
  * @param {string} jsPath The JS file to load
  * @param {string} [cssPath] An optional CSS file to load
  * @param {object[]} [args] Parameters to be passed to the default export when it is called
  */
-export async function loadModule(name, jsPath, cssPath, ...args) {
+export async function loadModule(jsPath, cssPath, ...args) {
   const cssLoaded = cssPath ? loadCSS(cssPath) : Promise.resolve();
   const decorationComplete = jsPath
-    ? new Promise((resolve) => {
+    ? new Promise((resolve, reject) => {
       (async () => {
         let mod;
         try {
@@ -75,8 +74,7 @@ export async function loadModule(name, jsPath, cssPath, ...args) {
             await mod.default.apply(null, args);
           }
         } catch (error) {
-          // eslint-disable-next-line no-console
-          console.log(`failed to load module for ${name}`, error);
+          reject(error);
         }
         resolve(mod);
       })();

--- a/src/plugins-registry.js
+++ b/src/plugins-registry.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { loadModule } from './dom-utils.js';
+
+export default class PluginsRegistry {
+  #plugins;
+
+  static parsePluginParams(id, config) {
+    const pluginId = !config
+      ? id.split('/').splice(id.endsWith('/') ? -2 : -1, 1)[0].replace(/\.js/, '')
+      : id;
+    const pluginConfig = typeof config === 'string' || !config
+      ? { url: (config || id).replace(/\/$/, '') }
+      : { load: 'eager', ...config };
+    pluginConfig.options ||= {};
+    return { id: pluginId, config: pluginConfig };
+  }
+
+  constructor() {
+    this.#plugins = new Map();
+  }
+
+  // Register a new plugin
+  add(id, config) {
+    const { id: pluginId, config: pluginConfig } = PluginsRegistry.parsePluginParams(id, config);
+    this.#plugins.set(pluginId, pluginConfig);
+  }
+
+  // Get the plugin
+  get(id) { return this.#plugins.get(id); }
+
+  // Check if the plugin exists
+  includes(id) { return !!this.#plugins.has(id); }
+
+  // Load all plugins that are referenced by URL, and updated their configuration with the
+  // actual API they expose
+  async load(phase, context) {
+    [...this.#plugins.entries()]
+      .filter(([, plugin]) => plugin.condition
+      && !plugin.condition(document, plugin.options, context))
+      .map(([id]) => this.#plugins.delete(id));
+    return Promise.all([...this.#plugins.entries()]
+      // Filter plugins that don't match the execution conditions
+      .filter(([, plugin]) => (
+        (!plugin.condition || plugin.condition(document, plugin.options, context))
+        && phase === plugin.load && plugin.url
+      ))
+      .map(async ([key, plugin]) => {
+        try {
+          // If the plugin has a default export, it will be executed immediately
+          const pluginApi = (await loadModule(
+            key,
+            !plugin.url.endsWith('.js') ? `${plugin.url}/${key}.js` : plugin.url,
+            !plugin.url.endsWith('.js') ? `${plugin.url}/${key}.css` : null,
+            document,
+            plugin.options,
+            context,
+          )) || {};
+          this.#plugins.set(key, { ...plugin, ...pluginApi });
+        } catch (err) {
+          // eslint-disable-next-line no-console
+          console.error('Could not load specified plugin', key);
+        }
+      }));
+  }
+
+  // Run a specific phase in the plugin
+  async run(phase, context) {
+    return [...this.#plugins.values()]
+      .reduce((promise, plugin) => ( // Using reduce to execute plugins sequencially
+        plugin[phase] && (!plugin.condition
+            || plugin.condition(document, plugin.options, context))
+          ? promise.then(() => plugin[phase](document, plugin.options, context))
+          : promise
+      ), Promise.resolve());
+  }
+}

--- a/src/plugins-registry.js
+++ b/src/plugins-registry.js
@@ -19,9 +19,12 @@ export default class PluginsRegistry {
     const pluginId = !config
       ? id.split('/').splice(id.endsWith('/') ? -2 : -1, 1)[0].replace(/\.js/, '')
       : id;
-    const pluginConfig = typeof config === 'string' || !config
-      ? { url: (config || id).replace(/\/$/, '') }
-      : { load: 'eager', ...config };
+    const pluginConfig = {
+      load: 'eager',
+      ...(typeof config === 'string' || !config
+        ? { url: (config || id).replace(/\/$/, '') }
+        : config),
+    };
     pluginConfig.options ||= {};
     return { id: pluginId, config: pluginConfig };
   }

--- a/src/plugins-registry.js
+++ b/src/plugins-registry.js
@@ -80,10 +80,10 @@ export default class PluginsRegistry {
   // Run a specific phase in the plugin
   async run(phase, context) {
     return [...this.#plugins.values()]
-      .reduce((promise, plugin) => ( // Using reduce to execute plugins sequencially
-        plugin[phase] && (!plugin.condition
-            || plugin.condition(document, plugin.options, context))
-          ? promise.then(() => plugin[phase](document, plugin.options, context))
+      .reduce((promise, p) => ( // Using reduce to execute plugins sequencially
+        p[phase] && (!p.condition
+            || p.condition(document, p.options, context))
+          ? promise.then(() => p[phase](document, p.options, context))
           : promise
       ), Promise.resolve());
   }

--- a/src/plugins-registry.js
+++ b/src/plugins-registry.js
@@ -62,9 +62,8 @@ export default class PluginsRegistry {
         try {
           // If the plugin has a default export, it will be executed immediately
           const pluginApi = (await loadModule(
-            key,
-            !plugin.url.endsWith('.js') ? `${plugin.url}/${key}.js` : plugin.url,
-            !plugin.url.endsWith('.js') ? `${plugin.url}/${key}.css` : null,
+            !plugin.url.endsWith('.js') ? `${plugin.url}/${plugin.url.split('/').pop()}.js` : plugin.url,
+            !plugin.url.endsWith('.js') ? `${plugin.url}/${plugin.url.split('/').pop()}.css` : null,
             document,
             plugin.options,
             context,
@@ -73,6 +72,7 @@ export default class PluginsRegistry {
         } catch (err) {
           // eslint-disable-next-line no-console
           console.error('Could not load specified plugin', key);
+          this.#plugins.delete(key);
         }
       }));
   }

--- a/src/setup.js
+++ b/src/setup.js
@@ -27,11 +27,12 @@ export function setup() {
   window.hlx.templates = new TemplatesRegistry();
 
   const scriptEl = document.querySelector('script[src$="/scripts/scripts.js"]');
+  /* c8 ignore next 1 */
   if (scriptEl) {
     try {
       [window.hlx.codeBasePath] = new URL(scriptEl.src).pathname.split('/scripts/scripts.js');
     } catch (error) {
-      /* c8 ignore next 3 */
+      /* c8 ignore next 2 */
       // eslint-disable-next-line no-console
       console.log(error);
     }

--- a/src/setup.js
+++ b/src/setup.js
@@ -11,6 +11,8 @@
  */
 
 import { sampleRUM } from '@adobe/helix-rum-js';
+import PluginsRegistry from './plugins-registry.js';
+import TemplatesRegistry from './templates-registry.js';
 
 /**
  * Setup block utils.
@@ -20,6 +22,9 @@ export function setup() {
   window.hlx.RUM_MASK_URL = 'full';
   window.hlx.codeBasePath = '';
   window.hlx.lighthouse = new URLSearchParams(window.location.search).get('lighthouse') === 'on';
+  window.hlx.patchBlockConfig = [];
+  window.hlx.plugins = new PluginsRegistry();
+  window.hlx.templates = new TemplatesRegistry();
 
   const scriptEl = document.querySelector('script[src$="/scripts/scripts.js"]');
   if (scriptEl) {

--- a/src/templates-registry.js
+++ b/src/templates-registry.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+import { getMetadata } from './dom-utils.js';
+import PluginsRegistry from './plugins-registry.js';
+import { toClassName } from './utils.js';
+
+export default class TemplatesRegistry {
+  // Register a new template
+  // eslint-disable-next-line class-methods-use-this
+  add(id, url) {
+    if (Array.isArray(id)) {
+      id.forEach((i) => this.add(i));
+      return;
+    }
+    const { id: templateId, config: templateConfig } = PluginsRegistry.parsePluginParams(id, url);
+    templateConfig.condition = () => toClassName(getMetadata('template')) === templateId;
+    window.hlx.plugins.add(templateId, templateConfig);
+  }
+
+  // Get the template
+  // eslint-disable-next-line class-methods-use-this
+  get(id) { return window.hlx.plugins.get(id); }
+
+  // Check if the template exists
+  // eslint-disable-next-line class-methods-use-this
+  includes(id) { return window.hlx.plugins.includes(id); }
+}

--- a/test/block-loader/loadBlock.customconfig.test.html
+++ b/test/block-loader/loadBlock.customconfig.test.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <main>
+      <div class="section">
+        <div class="wrapper">
+          <div class="ablock" data-block-name="asyncblock"></div>
+        </div>
+      </div>
+    </main>
+    
+    <script type="module">
+      /* eslint-env mocha */
+      import { runTests } from '@web/test-runner-mocha';
+      import { expect } from '@esm-bundle/chai';
+      import { setup } from '../../src/setup.js';
+      import { loadBlock } from '../../src/block-loader.js';
+
+      setup();
+
+      runTests(() => {
+        it('loadBlock - async block', async () => {
+          window.hlx.codeBasePath = '/test/fixtures';
+          // Modify the block name
+          window.hlx.patchBlockConfig.push((cfg) => ({
+            ...cfg,
+            blockName: `${cfg.blockName}-alt`,
+          }));
+          // Modify the css/js path using the new & original block name
+          window.hlx.patchBlockConfig.push((cfg, original) => ({
+            ...cfg,
+            cssPath: `/blocks-alt/${original.blockName}/${cfg.blockName}.css`,
+            jsPath: `/blocks-alt/${original.blockName}/${cfg.blockName}.js`,
+          }));
+
+          const block = document.querySelector('.ablock');
+
+          await loadBlock(block);
+
+          expect(block.classList.contains('ablock')).to.be.true;
+          expect(block.dataset.blockName).to.equal('asyncblock');
+          expect(block.dataset.blockStatus).to.equal('loaded');
+
+          const css = document.querySelector('link');
+          expect(css.href).to.contains('/blocks-alt/asyncblock/asyncblock-alt.css');
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/test/dom-utils/getAllMetadata.test.html
+++ b/test/dom-utils/getAllMetadata.test.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta property="foo:bar" content="baz">
+    <meta name="foo-qux" content="corge">
+  </head>
+  <body>
+    <script type="module">
+      /* eslint-env mocha */
+      import { runTests } from '@web/test-runner-mocha';
+      import { expect } from '@esm-bundle/chai';
+      import { getAllMetadata } from '../../src/dom-utils.js';
+
+      runTests(() => {
+        it('get scoped properties', () => {
+          expect(getAllMetadata('foo')).to.eql({
+            bar: 'baz',
+            qux: 'corge',
+          });
+        });
+
+        it('get properties for unknown scope', () => {
+          expect(getAllMetadata('bar')).to.eql({});
+        });
+
+        // Test a custom document
+        const testDoc = document.implementation.createHTMLDocument();
+        const titleMeta = testDoc.createElement('meta');
+        titleMeta.setAttribute('property', 'grault:bar');
+        titleMeta.setAttribute('content', 'baz');
+        testDoc.head.appendChild(titleMeta);
+
+        const descriptionMeta = testDoc.createElement('meta');
+        descriptionMeta.setAttribute('name', 'grault-qux');
+        descriptionMeta.setAttribute('content', 'corge');
+        testDoc.head.appendChild(descriptionMeta);
+
+        it('get scoped properties from custom document', () => {
+          expect(getAllMetadata('grault', testDoc)).to.eql({
+            bar: 'baz',
+            qux: 'corge',
+          });
+        });
+
+        it('get properties for unknown scope from custom document', () => {
+          expect(getAllMetadata('bar', testDoc)).to.eql({});
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/test/dom-utils/loadModule.test.js
+++ b/test/dom-utils/loadModule.test.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 Adobe. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+ * OF ANY KIND, either express or implied. See the License for the specific language
+ * governing permissions and limitations under the License.
+ */
+
+/* eslint-env mocha */
+/* eslint-disable no-unused-expressions */
+
+import { expect } from '@esm-bundle/chai';
+import { loadModule } from '../../src/dom-utils.js';
+
+describe('loadModule', () => {
+  it('loads the JS, returns the api and executes the default export', async () => {
+    const options = {};
+    const api = await loadModule('/test/fixtures/plugins/full-api.js', null, document, options);
+    expect(options.init).to.be.true;
+    expect(api.loadEager).to.not.be.undefined;
+    expect(api.loadLazy).to.not.be.undefined;
+    expect(api.loadDelayed).to.not.be.undefined;
+  });
+
+  it('loads and applies the CSS file', async () => {
+    await loadModule('/test/fixtures/plugins/complex/complex.js', '/test/fixtures/plugins/complex/complex.css', document, {});
+    expect(getComputedStyle(document.body).fontFamily).to.equal('system-ui');
+  });
+
+  it('throws if the file cannot be loaded', async () => {
+    expect(async () => { await loadModule('/invalid.js'); }).to.throw;
+  });
+});

--- a/test/dom-utils/loadModule.test.js
+++ b/test/dom-utils/loadModule.test.js
@@ -21,9 +21,9 @@ describe('loadModule', () => {
     const options = {};
     const api = await loadModule('/test/fixtures/plugins/full-api.js', null, document, options);
     expect(options.init).to.be.true;
-    expect(api.loadEager).to.not.be.undefined;
-    expect(api.loadLazy).to.not.be.undefined;
-    expect(api.loadDelayed).to.not.be.undefined;
+    expect(api.loadEager).to.exist;
+    expect(api.loadLazy).to.exist;
+    expect(api.loadDelayed).to.exist;
   });
 
   it('loads and applies the CSS file', async () => {

--- a/test/fixtures/plugins/complex/complex.css
+++ b/test/fixtures/plugins/complex/complex.css
@@ -1,0 +1,3 @@
+body {
+  font-family: system-ui;
+}

--- a/test/fixtures/plugins/complex/complex.js
+++ b/test/fixtures/plugins/complex/complex.js
@@ -1,0 +1,15 @@
+export default (_, options) => {
+  options.init = true;
+};
+
+export const loadEager = (_, options) => {
+  options.eager = true;
+};
+
+export const loadLazy = (_, options) => {
+  options.lazy = true;
+};
+
+export const loadDelayed = (_, options) => {
+  options.delayed = true;
+};

--- a/test/fixtures/plugins/full-api.js
+++ b/test/fixtures/plugins/full-api.js
@@ -1,0 +1,15 @@
+export default function init(_, options) {
+  options.init = true;
+}
+
+export function loadEager(_, options) {
+  options.eager = true;
+}
+
+export function loadLazy(_, options) {
+  options.lazy = true;
+}
+
+export function loadDelayed(_, options) {
+  options.delayed = true;
+}

--- a/test/fixtures/plugins/partial-api.js
+++ b/test/fixtures/plugins/partial-api.js
@@ -1,0 +1,7 @@
+export default (_, options) => {
+  options.init = true;
+};
+
+export const loadEager = (_, options) => {
+  options.eager = true;
+};

--- a/test/plugins-registry/plugins-registry.test.html
+++ b/test/plugins-registry/plugins-registry.test.html
@@ -24,7 +24,7 @@
               options: { foo: 'bar' },
             });
             const plugin = window.hlx.plugins.get('inline');
-            expect(plugin).to.not.be.undefined;
+            expect(plugin).to.exist;
             expect(plugin.options).to.eql({ foo: 'bar' });
             expect(window.hlx.plugins.includes('inline')).to.true;
           });
@@ -72,14 +72,14 @@
           it('registration and retrieval', async () => {
             window.hlx.plugins.add('/test/fixtures/plugins/partial-api.js');
             const plugin = window.hlx.plugins.get('partial-api');
-            expect(plugin).to.not.be.undefined;
+            expect(plugin).to.exist;
             expect(window.hlx.plugins.includes('partial-api')).to.true;
           });
 
           it('run the eager phase', async () => {
             await window.hlx.plugins.load('eager');
             const plugin = window.hlx.plugins.get('partial-api');
-            expect(plugin.loadEager).to.not.be.undefined;
+            expect(plugin.loadEager).to.exist;
             expect(plugin.loadLazy).to.be.undefined;
             expect(plugin.loadDelayed).to.be.undefined;
             sinon.spy(plugin, 'loadEager');
@@ -107,7 +107,7 @@
               url: '/test/fixtures/plugins/full-api.js',
             });
             let plugin = window.hlx.plugins.get('fullapi');
-            expect(plugin).to.not.be.undefined;
+            expect(plugin).to.exist;
             expect(window.hlx.plugins.includes('fullapi')).to.true;
             await window.hlx.plugins.load('eager');
             plugin = window.hlx.plugins.get('fullapi');
@@ -121,9 +121,9 @@
           it('run the eager phase', async () => {
             await window.hlx.plugins.load('eager');
             const plugin = window.hlx.plugins.get('fullapi');
-            expect(plugin.loadEager).to.not.be.undefined;
-            expect(plugin.loadLazy).to.not.be.undefined;
-            expect(plugin.loadDelayed).to.not.be.undefined;
+            expect(plugin.loadEager).to.exist;
+            expect(plugin.loadLazy).to.exist;
+            expect(plugin.loadDelayed).to.exist;
             sinon.spy(plugin, 'loadEager');
             await window.hlx.plugins.run('loadEager');
             sinon.assert.calledOnce(plugin.loadEager);
@@ -155,7 +155,7 @@
               url: '/test/fixtures/plugins/complex',
             });
             const plugin = window.hlx.plugins.get('complex');
-            expect(plugin).to.not.be.undefined;
+            expect(plugin).to.exist;
             expect(window.hlx.plugins.includes('complex')).to.true;
           });
 
@@ -170,9 +170,9 @@
           it('run the lazy phase', async () => {
             await window.hlx.plugins.load('lazy');
             const plugin = window.hlx.plugins.get('complex');
-            expect(plugin.loadEager).to.not.be.undefined;
-            expect(plugin.loadLazy).to.not.be.undefined;
-            expect(plugin.loadDelayed).to.not.be.undefined;
+            expect(plugin.loadEager).to.exist;
+            expect(plugin.loadLazy).to.exist;
+            expect(plugin.loadDelayed).to.exist;
             sinon.spy(plugin, 'loadEager');
             sinon.spy(plugin, 'loadLazy');
             await window.hlx.plugins.run('loadLazy');
@@ -196,88 +196,12 @@
           it('removes invalid plugins if loading fails', async () => {
             window.hlx.plugins.add('/invalid.js');
             let plugin = window.hlx.plugins.get('invalid');
-            expect(plugin).to.not.be.undefined;
+            expect(plugin).to.exist;
             await window.hlx.plugins.load('eager');
             plugin = window.hlx.plugins.get('invalid');
             expect(plugin).to.be.undefined;
           });
         });
-        // it('add a simple plugin', () => {
-        //   window.hlx.plugins.add('/test/fixtures/plugins/plugin1.js');
-        //   expect(window.hlx.plugins.get('plugin1')).to.not.be.null;
-        //   expect(window.hlx.plugins.get('plugin1')).to.have.property('url', '/test/fixtures/plugins/plugin1.js');
-        //   expect(window.hlx.plugins.get('plugin1')).to.have.property('load', 'eager');
-        // });
-
-        // it('add a named plugin', async () => {
-        //   window.hlx.plugins.add('plugin-2', {
-        //     url: '/test/fixtures/plugins/plugin2',
-        //     load: 'lazy',
-        //   });
-        //   expect(window.hlx.plugins.get('plugin-2')).to.not.be.null;
-        //   expect(window.hlx.plugins.get('plugin-2')).to.have.property('url', '/test/fixtures/plugins/plugin2');
-        //   expect(window.hlx.plugins.get('plugin-2')).to.have.property('load', 'lazy');
-        // });
-
-        // it('add a complex plugin', async () => {
-        //   window.hlx.plugins.add('plugin-3', {
-        //     url: '/test/fixtures/plugins/plugin3.js',
-        //     condition: () => window.loadPlugin3,
-        //     load: 'delayed',
-        //   });
-        //   expect(window.hlx.plugins.get('plugin-3')).to.not.be.null;
-        //   expect(window.hlx.plugins.get('plugin-3')).to.have.property('url', '/test/fixtures/plugins/plugin3.js');
-        //   expect(window.hlx.plugins.get('plugin-3')).to.have.property('load', 'delayed');
-        // });
-
-        // it('loads plugins according to their load property', async () => {
-        //   window.loadPlugin3 = true;
-        //   await window.hlx.plugins.load('eager');
-        //   expect(window.hlx.plugins.get('plugin1').options.init).to.be.true;
-        //   expect(window.hlx.plugins.get('plugin-2').options.init).to.be.undefined;
-        //   expect(window.hlx.plugins.get('plugin-3').options.init).to.be.undefined;
-        //   await window.hlx.plugins.load('lazy');
-        //   expect(window.hlx.plugins.get('plugin1').options.init).to.be.true;
-        //   expect(window.hlx.plugins.get('plugin-2').options.init).to.be.true;
-        //   expect(window.hlx.plugins.get('plugin-3').options.init).to.be.undefined;
-        //   await window.hlx.plugins.load('delayed');
-        //   expect(window.hlx.plugins.get('plugin1').options.init).to.be.true;
-        //   expect(window.hlx.plugins.get('plugin-2').options.init).to.be.true;
-        //   expect(window.hlx.plugins.get('plugin-3').options.init).to.be.true;
-        // });
-
-        // it('removes plugin if it fails loading', async () => {
-        //   window.hlx.plugins.add('/test/fixtures/plugins/plugin0.js');
-        //   expect(window.hlx.plugins.get('plugin0')).to.not.be.undefined;
-        //   await window.hlx.plugins.load('eager');
-        //   expect(window.hlx.plugins.get('plugin0')).to.be.undefined;
-        // });
-
-        // it('run the matching phase for a plugin', async () => {
-        //   window.loadPlugin3 = true;
-        //   window.hlx.plugins.add('plugin4', '/test/fixtures/plugins/plugin1.js');
-        //   window.hlx.plugins.add('plugin5', { url: '/test/fixtures/plugins/plugin2/plugin2.js', load: 'lazy' });
-        //   window.hlx.plugins.add('plugin6', { url: '/test/fixtures/plugins/plugin3.js', load: 'delayed', condition: () => window.loadPlugin3 });
-        //   await window.hlx.plugins.load('eager');
-        //   await window.hlx.plugins.run('loadEager');
-        //   expect(window.hlx.plugins.get('plugin4').options.eager).to.be.true;
-        //   expect(window.hlx.plugins.get('plugin5').options.eager).to.be.undefined;
-        //   expect(window.hlx.plugins.get('plugin6').options.eager).to.be.undefined;
-        //   await window.hlx.plugins.load('lazy');
-        //   await window.hlx.plugins.run('loadLazy');
-        //   expect(window.hlx.plugins.get('plugin4').options.lazy).to.be.undefined; // plugin1.js does not have a loadLazy export
-        //   expect(window.hlx.plugins.get('plugin5').options.lazy).to.be.true;
-        //   expect(window.hlx.plugins.get('plugin6').options.lazy).to.be.undefined; // plugin3.js is not loaded yet
-        //   await window.hlx.plugins.load('delayed');
-        //   window.hlx.plugins.get('plugin6').condition = () => false;
-        //   await window.hlx.plugins.run('loadDelayed');
-        //   expect(window.hlx.plugins.get('plugin4').options.delayed).to.be.undefined; // plugin1.js does not have a loadDelayed export
-        //   expect(window.hlx.plugins.get('plugin5').options.delayed).to.be.true;
-        //   expect(window.hlx.plugins.get('plugin6').options.delayed).to.be.undefined; // plugin3.js condition is not met
-        //   window.hlx.plugins.get('plugin6').condition = () => true;
-        //   await window.hlx.plugins.run('loadDelayed');
-        //   expect(window.hlx.plugins.get('plugin6').options.delayed).to.be.true;
-        // });
       });
     </script>
   </body>

--- a/test/plugins-registry/plugins-registry.test.html
+++ b/test/plugins-registry/plugins-registry.test.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html>
+  <head>
+  </head>
+  <body>
+    <script type="module">
+      /* eslint-env mocha */
+      import { runTests } from '@web/test-runner-mocha';
+      import { expect } from '@esm-bundle/chai';
+      import sinon from 'sinon';
+      import { setup } from '../../src/setup.js';
+
+      runTests(() => {
+        describe('inline plugin', () => {
+          before(() => {
+            setup();
+          });
+
+          it('registration and retrieval', async () => {
+            window.hlx.plugins.add('inline', {
+              loadEager: sinon.stub(),
+              loadLazy: sinon.stub(),
+              loadDelayed: sinon.stub(),
+              options: { foo: 'bar' },
+            });
+            const plugin = window.hlx.plugins.get('inline');
+            expect(plugin).to.not.be.undefined;
+            expect(plugin.options).to.eql({ foo: 'bar' });
+            expect(window.hlx.plugins.includes('inline')).to.true;
+          });
+
+          it('run the eager phase', async () => {
+            const plugin = window.hlx.plugins.get('inline');
+            await window.hlx.plugins.run('loadEager');
+            sinon.assert.calledOnce(plugin.loadEager);
+            sinon.assert.notCalled(plugin.loadLazy);
+            sinon.assert.notCalled(plugin.loadDelayed);
+          });
+
+          it('run the lazy phase', async () => {
+            const plugin = window.hlx.plugins.get('inline');
+            await window.hlx.plugins.run('loadLazy');
+            sinon.assert.calledOnce(plugin.loadEager);
+            sinon.assert.calledOnce(plugin.loadLazy);
+            sinon.assert.notCalled(plugin.loadDelayed);
+          });
+
+          it('run the delayed phase', async () => {
+            const plugin = window.hlx.plugins.get('inline');
+            await window.hlx.plugins.run('loadDelayed');
+            sinon.assert.calledOnce(plugin.loadEager);
+            sinon.assert.calledOnce(plugin.loadLazy);
+            sinon.assert.calledOnce(plugin.loadDelayed);
+          });
+
+          it('not running when condition is not met', async () => {
+            window.hlx.plugins.add('inline-alt', {
+              condition: () => false,
+              loadEager: (_, options) => { options.eager = true; },
+            });
+            await window.hlx.plugins.run('loadEager');
+            const plugin = window.hlx.plugins.get('inline-alt');
+            expect(plugin.options.eager).to.be.undefined;
+          });
+        });
+
+        describe('plugin with partial API', () => {
+          before(() => {
+            setup();
+          });
+
+          it('registration and retrieval', async () => {
+            window.hlx.plugins.add('/test/fixtures/plugins/partial-api.js');
+            const plugin = window.hlx.plugins.get('partial-api');
+            expect(plugin).to.not.be.undefined;
+            expect(window.hlx.plugins.includes('partial-api')).to.true;
+          });
+
+          it('run the eager phase', async () => {
+            await window.hlx.plugins.load('eager');
+            const plugin = window.hlx.plugins.get('partial-api');
+            expect(plugin.loadEager).to.not.be.undefined;
+            expect(plugin.loadLazy).to.be.undefined;
+            expect(plugin.loadDelayed).to.be.undefined;
+            sinon.spy(plugin, 'loadEager');
+            await window.hlx.plugins.run('loadEager');
+            sinon.assert.calledOnce(plugin.loadEager);
+          });
+
+          it('run the lazy phase', () => {
+            expect(async () => window.hlx.plugins.run('loadLazy')).to.not.throw;
+          });
+
+          it('run the delayed phase', () => {
+            expect(async () => window.hlx.plugins.run('loadDelayed')).to.not.throw;
+          });
+        });
+
+        describe('plugin with full API', () => {
+          before(() => {
+            setup();
+          });
+
+          it('registration and retrieval', async () => {
+            window.hlx.plugins.add('fullapi', {
+              condition: () => false,
+              url: '/test/fixtures/plugins/full-api.js',
+            });
+            let plugin = window.hlx.plugins.get('fullapi');
+            expect(plugin).to.not.be.undefined;
+            expect(window.hlx.plugins.includes('fullapi')).to.true;
+            await window.hlx.plugins.load('eager');
+            plugin = window.hlx.plugins.get('fullapi');
+            expect(plugin).to.be.undefined; // condition not met, so plugin is removed
+            window.hlx.plugins.add('fullapi', {
+              condition: () => true,
+              url: '/test/fixtures/plugins/full-api.js',
+            });
+          });
+
+          it('run the eager phase', async () => {
+            await window.hlx.plugins.load('eager');
+            const plugin = window.hlx.plugins.get('fullapi');
+            expect(plugin.loadEager).to.not.be.undefined;
+            expect(plugin.loadLazy).to.not.be.undefined;
+            expect(plugin.loadDelayed).to.not.be.undefined;
+            sinon.spy(plugin, 'loadEager');
+            await window.hlx.plugins.run('loadEager');
+            sinon.assert.calledOnce(plugin.loadEager);
+          });
+
+          it('run the lazy phase', async () => {
+            const plugin = window.hlx.plugins.get('fullapi');
+            sinon.spy(plugin, 'loadLazy');
+            await window.hlx.plugins.run('loadLazy');
+            sinon.assert.calledOnce(plugin.loadLazy);
+          });
+
+          it('run the delayed phase', async () => {
+            const plugin = window.hlx.plugins.get('fullapi');
+            sinon.spy(plugin, 'loadDelayed');
+            await window.hlx.plugins.run('loadDelayed');
+            sinon.assert.calledOnce(plugin.loadDelayed);
+          });
+        });
+
+        describe('plugin with JS and CSS', () => {
+          before(() => {
+            setup();
+          });
+
+          it('registration and retrieval', async () => {
+            window.hlx.plugins.add('complex', {
+              load: 'lazy',
+              url: '/test/fixtures/plugins/complex',
+            });
+            const plugin = window.hlx.plugins.get('complex');
+            expect(plugin).to.not.be.undefined;
+            expect(window.hlx.plugins.includes('complex')).to.true;
+          });
+
+          it('run the eager phase', async () => {
+            await window.hlx.plugins.load('eager');
+            const plugin = window.hlx.plugins.get('complex');
+            expect(plugin.loadEager).to.be.undefined;
+            expect(plugin.loadLazy).to.be.undefined;
+            expect(plugin.loadDelayed).to.be.undefined;
+          });
+
+          it('run the lazy phase', async () => {
+            await window.hlx.plugins.load('lazy');
+            const plugin = window.hlx.plugins.get('complex');
+            expect(plugin.loadEager).to.not.be.undefined;
+            expect(plugin.loadLazy).to.not.be.undefined;
+            expect(plugin.loadDelayed).to.not.be.undefined;
+            sinon.spy(plugin, 'loadEager');
+            sinon.spy(plugin, 'loadLazy');
+            await window.hlx.plugins.run('loadLazy');
+            sinon.assert.notCalled(plugin.loadEager);
+            sinon.assert.calledOnce(plugin.loadLazy);
+          });
+
+          it('run the delayed phase', async () => {
+            const plugin = window.hlx.plugins.get('complex');
+            sinon.spy(plugin, 'loadDelayed');
+            await window.hlx.plugins.run('loadDelayed');
+            sinon.assert.calledOnce(plugin.loadDelayed);
+          });
+        });
+
+        describe('Generic', () => {
+          before(() => {
+            setup();
+          });
+
+          it('removes invalid plugins if loading fails', async () => {
+            window.hlx.plugins.add('/invalid.js');
+            let plugin = window.hlx.plugins.get('invalid');
+            expect(plugin).to.not.be.undefined;
+            await window.hlx.plugins.load('eager');
+            plugin = window.hlx.plugins.get('invalid');
+            expect(plugin).to.be.undefined;
+          });
+        });
+        // it('add a simple plugin', () => {
+        //   window.hlx.plugins.add('/test/fixtures/plugins/plugin1.js');
+        //   expect(window.hlx.plugins.get('plugin1')).to.not.be.null;
+        //   expect(window.hlx.plugins.get('plugin1')).to.have.property('url', '/test/fixtures/plugins/plugin1.js');
+        //   expect(window.hlx.plugins.get('plugin1')).to.have.property('load', 'eager');
+        // });
+
+        // it('add a named plugin', async () => {
+        //   window.hlx.plugins.add('plugin-2', {
+        //     url: '/test/fixtures/plugins/plugin2',
+        //     load: 'lazy',
+        //   });
+        //   expect(window.hlx.plugins.get('plugin-2')).to.not.be.null;
+        //   expect(window.hlx.plugins.get('plugin-2')).to.have.property('url', '/test/fixtures/plugins/plugin2');
+        //   expect(window.hlx.plugins.get('plugin-2')).to.have.property('load', 'lazy');
+        // });
+
+        // it('add a complex plugin', async () => {
+        //   window.hlx.plugins.add('plugin-3', {
+        //     url: '/test/fixtures/plugins/plugin3.js',
+        //     condition: () => window.loadPlugin3,
+        //     load: 'delayed',
+        //   });
+        //   expect(window.hlx.plugins.get('plugin-3')).to.not.be.null;
+        //   expect(window.hlx.plugins.get('plugin-3')).to.have.property('url', '/test/fixtures/plugins/plugin3.js');
+        //   expect(window.hlx.plugins.get('plugin-3')).to.have.property('load', 'delayed');
+        // });
+
+        // it('loads plugins according to their load property', async () => {
+        //   window.loadPlugin3 = true;
+        //   await window.hlx.plugins.load('eager');
+        //   expect(window.hlx.plugins.get('plugin1').options.init).to.be.true;
+        //   expect(window.hlx.plugins.get('plugin-2').options.init).to.be.undefined;
+        //   expect(window.hlx.plugins.get('plugin-3').options.init).to.be.undefined;
+        //   await window.hlx.plugins.load('lazy');
+        //   expect(window.hlx.plugins.get('plugin1').options.init).to.be.true;
+        //   expect(window.hlx.plugins.get('plugin-2').options.init).to.be.true;
+        //   expect(window.hlx.plugins.get('plugin-3').options.init).to.be.undefined;
+        //   await window.hlx.plugins.load('delayed');
+        //   expect(window.hlx.plugins.get('plugin1').options.init).to.be.true;
+        //   expect(window.hlx.plugins.get('plugin-2').options.init).to.be.true;
+        //   expect(window.hlx.plugins.get('plugin-3').options.init).to.be.true;
+        // });
+
+        // it('removes plugin if it fails loading', async () => {
+        //   window.hlx.plugins.add('/test/fixtures/plugins/plugin0.js');
+        //   expect(window.hlx.plugins.get('plugin0')).to.not.be.undefined;
+        //   await window.hlx.plugins.load('eager');
+        //   expect(window.hlx.plugins.get('plugin0')).to.be.undefined;
+        // });
+
+        // it('run the matching phase for a plugin', async () => {
+        //   window.loadPlugin3 = true;
+        //   window.hlx.plugins.add('plugin4', '/test/fixtures/plugins/plugin1.js');
+        //   window.hlx.plugins.add('plugin5', { url: '/test/fixtures/plugins/plugin2/plugin2.js', load: 'lazy' });
+        //   window.hlx.plugins.add('plugin6', { url: '/test/fixtures/plugins/plugin3.js', load: 'delayed', condition: () => window.loadPlugin3 });
+        //   await window.hlx.plugins.load('eager');
+        //   await window.hlx.plugins.run('loadEager');
+        //   expect(window.hlx.plugins.get('plugin4').options.eager).to.be.true;
+        //   expect(window.hlx.plugins.get('plugin5').options.eager).to.be.undefined;
+        //   expect(window.hlx.plugins.get('plugin6').options.eager).to.be.undefined;
+        //   await window.hlx.plugins.load('lazy');
+        //   await window.hlx.plugins.run('loadLazy');
+        //   expect(window.hlx.plugins.get('plugin4').options.lazy).to.be.undefined; // plugin1.js does not have a loadLazy export
+        //   expect(window.hlx.plugins.get('plugin5').options.lazy).to.be.true;
+        //   expect(window.hlx.plugins.get('plugin6').options.lazy).to.be.undefined; // plugin3.js is not loaded yet
+        //   await window.hlx.plugins.load('delayed');
+        //   window.hlx.plugins.get('plugin6').condition = () => false;
+        //   await window.hlx.plugins.run('loadDelayed');
+        //   expect(window.hlx.plugins.get('plugin4').options.delayed).to.be.undefined; // plugin1.js does not have a loadDelayed export
+        //   expect(window.hlx.plugins.get('plugin5').options.delayed).to.be.true;
+        //   expect(window.hlx.plugins.get('plugin6').options.delayed).to.be.undefined; // plugin3.js condition is not met
+        //   window.hlx.plugins.get('plugin6').condition = () => true;
+        //   await window.hlx.plugins.run('loadDelayed');
+        //   expect(window.hlx.plugins.get('plugin6').options.delayed).to.be.true;
+        // });
+      });
+    </script>
+  </body>
+</html>

--- a/test/plugins-registry/plugins-registry.test.html
+++ b/test/plugins-registry/plugins-registry.test.html
@@ -178,6 +178,7 @@
             await window.hlx.plugins.run('loadLazy');
             sinon.assert.notCalled(plugin.loadEager);
             sinon.assert.calledOnce(plugin.loadLazy);
+            expect(getComputedStyle(document.body).fontFamily).to.equal('system-ui');
           });
 
           it('run the delayed phase', async () => {

--- a/test/plugins-registry/plugins-registry.test.html
+++ b/test/plugins-registry/plugins-registry.test.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="/some/path/scripts/scripts.js"></script>
   </head>
   <body>
     <script type="module">

--- a/test/plugins-registry/plugins-registry.test.html
+++ b/test/plugins-registry/plugins-registry.test.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <script src="/some/path/scripts/scripts.js"></script>
   </head>
   <body>
     <script type="module">

--- a/test/setup/setup.test.html
+++ b/test/setup/setup.test.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="/some/path/scripts/scripts.js"></script>
   </head>
   <body>
     <script type="module">
@@ -28,6 +27,9 @@
         });
 
         it('setup - sets some globals', () => {
+          const script = document.createElement('script');
+          script.src = '/some/path/scripts/scripts.js';
+          document.head.append(script);
           setup();
           expect(window.hlx).to.not.be.null;
           expect(window.hlx.codeBasePath).to.be.equal('/some/path');

--- a/test/setup/setup.test.html
+++ b/test/setup/setup.test.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <script src="/some/path/scripts/scripts.js"></script>
   </head>
   <body>
     <script type="module">
@@ -27,9 +28,6 @@
         });
 
         it('setup - sets some globals', () => {
-          const script = document.createElement('script');
-          script.src = '/some/path/scripts/scripts.js';
-          document.head.append(script);
           setup();
           expect(window.hlx).to.not.be.null;
           expect(window.hlx.codeBasePath).to.be.equal('/some/path');
@@ -39,11 +37,18 @@
           expect(window.hlx.templates).to.exist;
         });
 
-        it('setup - handles invalid script url', () => {
+        it('setup - handles invalid script.js url', () => {
           window.hlx.codeBasePath = null;
           const script = document.querySelector('script[src="/some/path/scripts/scripts.js"]');
           script.src = 'tel:/scripts/scripts.js"';
           document.head.append(script);
+          setup();
+          expect(window.hlx.codeBasePath).to.be.equal('');
+          script.remove();
+        });
+
+        it('setup - handles missing scripts.js', () => {
+          window.hlx.codeBasePath = null;
           setup();
           expect(window.hlx.codeBasePath).to.be.equal('');
         });

--- a/test/setup/setup.test.html
+++ b/test/setup/setup.test.html
@@ -36,22 +36,6 @@
           expect(window.hlx.plugins).to.exist;
           expect(window.hlx.templates).to.exist;
         });
-
-        it('setup - handles invalid script.js url', () => {
-          window.hlx.codeBasePath = null;
-          const script = document.querySelector('script[src="/some/path/scripts/scripts.js"]');
-          script.src = 'tel:/scripts/scripts.js"';
-          document.head.append(script);
-          setup();
-          expect(window.hlx.codeBasePath).to.be.equal('');
-          script.remove();
-        });
-
-        it('setup - handles missing scripts.js', () => {
-          window.hlx.codeBasePath = null;
-          setup();
-          expect(window.hlx.codeBasePath).to.be.equal('');
-        });
       });
     </script>
   </body>

--- a/test/setup/setup.test.html
+++ b/test/setup/setup.test.html
@@ -38,6 +38,15 @@
           expect(window.hlx.plugins).to.exist;
           expect(window.hlx.templates).to.exist;
         });
+
+        it('setup - handles invalid script url', () => {
+          window.hlx.codeBasePath = null;
+          const script = document.querySelector('script[src="/some/path/scripts/scripts.js"]');
+          script.src = 'tel:/scripts/scripts.js"';
+          document.head.append(script);
+          setup();
+          expect(window.hlx.codeBasePath).to.be.equal('');
+        });
       });
     </script>
   </body>

--- a/test/setup/setup.test.html
+++ b/test/setup/setup.test.html
@@ -32,6 +32,9 @@
           expect(window.hlx).to.not.be.null;
           expect(window.hlx.codeBasePath).to.be.equal('/some/path');
           expect(window.hlx.lighthouse).to.be.false;
+          expect(window.hlx.patchBlockConfig).to.be.eql([]);
+          expect(window.hlx.plugins).to.exist;
+          expect(window.hlx.templates).to.exist;
         });
       });
     </script>

--- a/test/templates-registry/templates-registry.test.html
+++ b/test/templates-registry/templates-registry.test.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <script src="/some/path/scripts/scripts.js"></script>
     <meta name="template" content="foo"/>
   </head>
   <body>

--- a/test/templates-registry/templates-registry.test.html
+++ b/test/templates-registry/templates-registry.test.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="template" content="foo"/>
+  </head>
+  <body>
+    <script type="module">
+      /* eslint-env mocha */
+      import { runTests } from '@web/test-runner-mocha';
+      import { expect } from '@esm-bundle/chai';
+      import { setup } from '../../src/setup.js';
+
+      runTests(() => {
+        before(() => {
+          setup();
+        });
+
+        it('add a simple template', () => {
+          window.hlx.templates.add('/foo.js');
+          expect(window.hlx.templates.get('foo')).to.not.be.null;
+          expect(window.hlx.templates.get('foo')).to.have.property('url', '/foo.js');
+          expect(window.hlx.templates.get('foo')).to.have.property('load', 'eager');
+          expect(window.hlx.templates.get('foo').condition()).to.be.true;
+        });
+
+        it('add a named template', () => {
+          window.hlx.templates.add('bar', '/foo.js');
+          expect(window.hlx.templates.get('bar')).to.not.be.null;
+          expect(window.hlx.templates.get('bar')).to.have.property('url', '/foo.js');
+          expect(window.hlx.templates.get('bar')).to.have.property('load', 'eager');
+          expect(window.hlx.templates.get('bar').condition()).to.be.false;
+        });
+
+        it('adds multiple templates', () => {
+          window.hlx.templates.add(['/baz.js', '/qux.js']);
+          expect(window.hlx.templates.get('baz')).to.not.be.null;
+          expect(window.hlx.templates.get('baz')).to.have.property('url', '/baz.js');
+          expect(window.hlx.templates.get('baz')).to.have.property('load', 'eager');
+          expect(window.hlx.templates.get('qux')).to.not.be.null;
+          expect(window.hlx.templates.get('qux')).to.have.property('url', '/qux.js');
+          expect(window.hlx.templates.get('qux')).to.have.property('load', 'eager');
+        });
+
+        it('includes returns true if template exists', () => {
+          window.hlx.templates.add('/corge.js');
+          expect(window.hlx.templates.includes('corge')).to.be.true;
+        });
+
+        it('includes returns false if template does not exist', () => {
+          expect(window.hlx.templates.includes('grault')).to.be.false;
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/test/templates-registry/templates-registry.test.html
+++ b/test/templates-registry/templates-registry.test.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <script src="/some/path/scripts/scripts.js"></script>
     <meta name="template" content="foo"/>
   </head>
   <body>


### PR DESCRIPTION
This adds a minimal plugin/template loading system that can hook into the various ELD phases.


## Description

See https://github.com/adobe/aem-boilerplate/pull/254 for full details

## How Has This Been Tested?

TBD: petplace, bamboohr, aem.live

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
