### PR TITLE
chore: add url and id as default plugin options

### DIFF
--- a/src/plugins-registry.js
+++ b/src/plugins-registry.js
@@ -26,6 +26,10 @@ export default class PluginsRegistry {
         : config),
     };
     pluginConfig.options ||= {};
+    pluginConfig.options.id ||= pluginId;
+    if (!pluginConfig.options.url && pluginConfig.url) {
+      pluginConfig.options.url ||= pluginConfig.url;
+    }
     return { id: pluginId, config: pluginConfig };
   }
 

--- a/test/plugins-registry/plugins-registry.test.html
+++ b/test/plugins-registry/plugins-registry.test.html
@@ -25,7 +25,7 @@
             });
             const plugin = window.hlx.plugins.get('inline');
             expect(plugin).to.exist;
-            expect(plugin.options).to.eql({ foo: 'bar' });
+            expect(plugin.options).to.eql({ foo: 'bar', id: 'inline' });
             expect(window.hlx.plugins.includes('inline')).to.true;
           });
 
@@ -108,6 +108,7 @@
             });
             let plugin = window.hlx.plugins.get('fullapi');
             expect(plugin).to.exist;
+            expect(plugin.options).to.eql({ url: '/test/fixtures/plugins/full-api.js', id: 'fullapi' });
             expect(window.hlx.plugins.includes('fullapi')).to.true;
             await window.hlx.plugins.load('eager');
             plugin = window.hlx.plugins.get('fullapi');


### PR DESCRIPTION
Add to the plugin options the `url` of the plugin if not inline plugin, and the `id`.
This information may be useful for some plugins to know with which id the are added to the system and in which path they are being loaded