### PR TITLE
refactor: use window.location as base for url construction

### DIFF
--- a/src/dom-utils.js
+++ b/src/dom-utils.js
@@ -77,7 +77,7 @@ export function getMetadata(name, doc = document) {
  * @returns {Element} The picture element
  */
 export function createOptimizedPicture(src, alt = '', eager = false, breakpoints = [{ media: '(min-width: 600px)', width: '2000' }, { width: '750' }]) {
-  const url = new URL(src, window.location.href);
+  const url = new URL(src, window.location);
   const picture = document.createElement('picture');
   const { pathname } = url;
   const ext = pathname.substring(pathname.lastIndexOf('.') + 1);

--- a/src/setup.js
+++ b/src/setup.js
@@ -24,7 +24,7 @@ export function setup() {
   const scriptEl = document.querySelector('script[src$="/scripts/scripts.js"]');
   if (scriptEl) {
     try {
-      [window.hlx.codeBasePath] = new URL(scriptEl.src).pathname.split('/scripts/scripts.js');
+      [window.hlx.codeBasePath] = new URL(scriptEl.src, window.location).pathname.split('/scripts/scripts.js');
     } catch (error) {
       /* c8 ignore next 3 */
       // eslint-disable-next-line no-console


### PR DESCRIPTION
## Description

Replaces instances of creating URL objects with a single argument with the two-argument form, using `window.location` as the base URL. 

## Motivation and Context

Ensures that relative URLs are resolved against the current browser location for consistent handling.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
