### PR TITLE
feat: add alt text support to decorateIcon

### DIFF
--- a/src/decorate.js
+++ b/src/decorate.js
@@ -54,7 +54,7 @@ export function decorateIcon(span, prefix = '', alt = '') {
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
   img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
-  img.alt = alt.trim();
+  img.alt = alt;
   img.loading = 'lazy';
   span.append(img);
 }

--- a/src/decorate.js
+++ b/src/decorate.js
@@ -45,14 +45,16 @@ export function decorateButtons(element) {
 
 /**
  * Add <img> for icon, prefixed with codeBasePath and optional prefix.
- * @param {span} [element] span element with icon classes
- * @param {string} [prefix] prefix to be added to icon the src
+ * @param {Element} [span] span element with icon classes
+ * @param {string} [prefix] prefix to be added to icon src
+ * @param {string} [alt] alt text to be added to icon
  */
-export function decorateIcon(span, prefix = '') {
+export function decorateIcon(span, prefix = '', alt = '') {
   const iconName = Array.from(span.classList).find((c) => c.startsWith('icon-')).substring(5);
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
   img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
+  img.alt = alt.trim();
   img.loading = 'lazy';
   span.append(img);
 }

--- a/test/decorate/decorateIcon.test.html
+++ b/test/decorate/decorateIcon.test.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+  <script type="module">
+    /* eslint-env mocha */
+    import { runTests } from '@web/test-runner-mocha';
+    import { expect } from '@esm-bundle/chai';
+    import { decorateIcon } from '../../src/decorate.js';
+
+    window.hlx = {};
+
+    runTests(() => {
+      it('decorates icons with alt text', async () => {
+        window.hlx.codeBasePath = '/test/fixtures';
+
+        const iconA = document.createElement('span');
+        iconA.className = 'icon icon-a';
+        decorateIcon(iconA, '', 'icon a alt text');
+
+        const iconB = document.createElement('span');
+        iconB.className = 'icon icon-b';
+        decorateIcon(iconB);
+
+        document.body.prepend(iconA, iconB);
+
+        const icons = document.querySelectorAll('.icon');
+        icons.forEach((icon) => {
+          expect(icon.firstElementChild.alt).to.exist;
+          if (icon === iconA) {
+            expect(icon.firstElementChild.alt).to.be.equal('icon a alt text');
+          } else if (icon === iconB) {
+            expect(icon.firstElementChild.alt).to.be.equal('');
+          }
+        });
+      });
+    });
+  </script>
+</body>
+</html>

--- a/test/decorate/decorateIcons.parallel.test.html
+++ b/test/decorate/decorateIcons.parallel.test.html
@@ -29,6 +29,7 @@
         icons.forEach((icon) => {
           expect(icon.childElementCount).to.be.equal(1);
           expect(icon.firstElementChild.tagName).to.be.equal('IMG');
+          expect(icon.firstElementChild.alt).to.be.equal('');
           expect(icon.firstElementChild.loading).to.be.equal('lazy');
         });
       });

--- a/test/decorate/decorateIcons.test.html
+++ b/test/decorate/decorateIcons.test.html
@@ -26,6 +26,7 @@
         icons.forEach((icon) => {
           expect(icon.childElementCount).to.be.equal(1);
           expect(icon.firstElementChild.tagName).to.be.equal('IMG');
+          expect(icon.firstElementChild.alt).to.be.equal('');
           expect(icon.firstElementChild.loading).to.be.equal('lazy');
         });
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Moving [@bstopp's PR](https://github.com/adobe/aem-boilerplate/pull/280) from `aem-boilerplate`. 

Opting for an empty `alt` attribute here in lieu of setting `role` attribute to `presentation` based on recommendations from [Web Hypertext Application Technology Working Group](https://html.spec.whatwg.org/multipage/images.html#a-short-phrase-or-label-with-an-alternative-graphical-representation:-icons,-logos) and the [Web Accessibility
Initiative](https://www.w3.org/WAI/tutorials/images/decorative/#:~:text=Screen%20readers%20also%20allow%20the%20use%20of%20WAI%2DARIA%20to%20hide%20elements%20by%20using%20role%3D%22presentation%22.%20However%2C%20currently%2C%20this%20feature%20is%20not%20as%20widely%20supported%20as%20using%20a%20null%20alt%20attribute.).

The [Worldwide Web Consortium](https://www.w3.org/TR/wai-aria-1.0/roles#presentation:~:text=An%20image%20that%20is%20in%20a%20container%20with%20the%20img%20role%20and%20where%20the%20full%20text%20alternative%20is%20available%20and%20is%20marked%20up%20with%20aria-labelledby%20and%20(if%20needed)%20aria-describedby%3B) provides an example for the use of `role="presentation"`:

> An image that is in a container with the `img` role and where the full text alternative is available and is marked up with [aria-labelledby](https://www.w3.org/TR/wai-aria-1.0/states_and_properties#aria-labelledby) and (if needed) [aria-describedby](https://www.w3.org/TR/wai-aria-1.0/states_and_properties#aria-describedby);

Where, in this instance, we don't meet that threshold without the "full text alternative" in this specific implementation. 

## Related Issue

#18 

## Motivation and Context

> "The Lighthouse output results in a "Links do not have a discernible name" accessibility error which reduces the score" &mdash; [@dave-fink](https://github.com/adobe/aem-lib/issues/13#issue-1898522678)

> "By default, all icons would be purely decorative (most cases), but projects could opt-in to individually override icons they know should be descriptive either in their blocks or in the auto-blocking function." &mdash; [@ramboz](https://github.com/adobe/aem-lib/issues/18#issuecomment-1778905342)

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

[/test/decorate/decorateIcon.test.html](https://github.com/adobe/aem-lib/blob/490fc4cfc3f2a2817020632d00d4f3113ed9e2e3/test/decorate/decorateIcon.test.html)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
