### PR TITLE
Remove obsolete destructuring in decorate.js::decorateIcons

### DIFF
--- a/src/decorate.js
+++ b/src/decorate.js
@@ -65,7 +65,7 @@ export function decorateIcon(span, prefix = '', alt = '') {
  * @param {string} [prefix] prefix to be added to icon the src
  */
 export function decorateIcons(element, prefix = '') {
-  const icons = [...element.querySelectorAll('span.icon')];
+  const icons = element.querySelectorAll('span.icon');
   icons.forEach((span) => {
     decorateIcon(span, prefix);
   });


### PR DESCRIPTION
# remove obsolete destructuring in decorate.js::decorateIcons

## Description

The destructuring here is unnecessary cause a `NodeList`, which is the return type for `querySelectorAll` supports `forEach` too and we also don't have to get rid of any references.

## Related Issue

https://github.com/adobe/aem-lib/issues/40

## Motivation and Context

is eliminates obsolete code

## How Has This Been Tested?

By removing it in local development and everything still works fine

## Screenshots (if appropriate):

n/a

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
