### PR TITLE
refactor: decorate buttons

### DIFF
--- a/dist/aem.js
+++ b/dist/aem.js
@@ -373,37 +373,33 @@ function decorateTemplateAndTheme() {
 }
 
 /**
- * Decorates paragraphs containing a single link as buttons.
+ * Decorates single links in paragraphs within a container element as buttons.
  * @param {Element} element container element
  */
 function decorateButtons(element) {
-  element.querySelectorAll('a').forEach((a) => {
+  element.querySelectorAll('a[href]').forEach((a) => {
     a.title = a.title || a.textContent;
     if (a.href !== a.textContent) {
-      const up = a.parentElement;
-      const twoup = a.parentElement.parentElement;
-      if (!a.querySelector('img')) {
-        if (up.childNodes.length === 1 && (up.tagName === 'P' || up.tagName === 'DIV')) {
-          a.className = 'button'; // default
-          up.classList.add('button-container');
+      const linkedImg = a.querySelector('img');
+      if (!linkedImg) {
+        let wrapper = a.closest('p');
+        if (!wrapper) {
+          const inList = a.closest('li');
+          const inBlock = a.closest('[class]');
+          if (!inList && inBlock) {
+            // wrap unwrapped block links in paragraph tag
+            const cell = a.closest('div');
+            const p = document.createElement('p');
+            while (cell.firstChild) p.append(cell.firstChild);
+            cell.replaceChildren(p);
+            wrapper = p;
+          }
         }
-        if (
-          up.childNodes.length === 1
-          && up.tagName === 'STRONG'
-          && twoup.childNodes.length === 1
-          && twoup.tagName === 'P'
-        ) {
-          a.className = 'button primary';
-          twoup.classList.add('button-container');
-        }
-        if (
-          up.childNodes.length === 1
-          && up.tagName === 'EM'
-          && twoup.childNodes.length === 1
-          && twoup.tagName === 'P'
-        ) {
-          a.className = 'button secondary';
-          twoup.classList.add('button-container');
+        if (wrapper && wrapper.childNodes.length === 1) {
+          wrapper.className = 'button-container';
+          a.className = 'button';
+          if (wrapper.querySelector('strong')) a.classList.add('primary');
+          if (wrapper.querySelector('em')) a.classList.add('secondary');
         }
       }
     }

--- a/src/decorate.js
+++ b/src/decorate.js
@@ -14,29 +14,33 @@ import { toCamelCase, toClassName } from './utils.js';
 import { readBlockConfig } from './block-utils.js';
 
 /**
- * Decorates paragraphs containing a single link as buttons.
+ * Decorates single links in paragraphs within a container element as buttons.
  * @param {Element} element container element
  */
 export function decorateButtons(element) {
-  element.querySelectorAll('a').forEach((a) => {
+  element.querySelectorAll('a[href]').forEach((a) => {
     a.title = a.title || a.textContent;
     if (a.href !== a.textContent) {
-      const up = a.parentElement;
-      const twoup = a.parentElement.parentElement;
-      if (!a.querySelector('img')) {
-        if (up.childNodes.length === 1 && (up.tagName === 'P' || up.tagName === 'DIV')) {
-          a.className = 'button'; // default
-          up.classList.add('button-container');
+      const linkedImg = a.querySelector('img');
+      if (!linkedImg) {
+        let wrapper = a.closest('p');
+        if (!wrapper) {
+          const inList = a.closest('li');
+          const inBlock = a.closest('[class]');
+          if (!inList && inBlock) {
+            // wrap unwrapped block links in paragraph tag
+            const cell = a.closest('div');
+            const p = document.createElement('p');
+            while (cell.firstChild) p.append(cell.firstChild);
+            cell.replaceChildren(p);
+            wrapper = p;
+          }
         }
-        if (up.childNodes.length === 1 && up.tagName === 'STRONG'
-          && twoup.childNodes.length === 1 && twoup.tagName === 'P') {
-          a.className = 'button primary';
-          twoup.classList.add('button-container');
-        }
-        if (up.childNodes.length === 1 && up.tagName === 'EM'
-          && twoup.childNodes.length === 1 && twoup.tagName === 'P') {
-          a.className = 'button secondary';
-          twoup.classList.add('button-container');
+        if (wrapper && wrapper.childNodes.length === 1) {
+          wrapper.className = 'button-container';
+          a.className = 'button';
+          if (wrapper.querySelector('strong')) a.classList.add('primary');
+          if (wrapper.querySelector('em')) a.classList.add('secondary');
         }
       }
     }

--- a/test/decorate/decorateButtons.test.html
+++ b/test/decorate/decorateButtons.test.html
@@ -1,86 +1,57 @@
 <!DOCTYPE html>
 <html lang="en">
-<body>
-  <div>
-    <h1 id="congrats-you-are-ready-to-go">Congrats, you are ready to go!</h1>
-    <p>Your forked repo is setup as an AEM project and you are ready to start developing.<br>The content you are looking at is served from this <a href="https://drive.google.com/drive/folders/1MGzOt7ubUh3gu7zhZIPb7R7dyRzG371j?usp=sharing">gdrive</a><br><br>Adjust the <code>fstab.yaml</code> to point to a folder either in your shared sharepoint or your shared gdrive. See the full tutorial here:<br><br><a href="https://bit.ly/3aImqUL">https://www.hlx.live/tutorial</a></p>
-    <h2 id="this-is-another-headline-here-for-more-content">This is another headline here for more content</h2>
-    <div class="columns">
-      <div>
+  <body>
+    <div>
+      <h1 id="congrats-you-are-ready-to-go">Congrats, you are ready to go!</h1>
+      <p>Your forked repo is set up as an AEM Project and you are ready to start developing.</p>
+      <p>The content you are looking at is served from this <a href="https://drive.google.com/drive/folders/1MGzOt7ubUh3gu7zhZIPb7R7dyRzG371j?usp=sharing">Google Drive</a></p>
+      <p>Adjust the <code>fstab.yaml</code> to point to a folder either in your sharepoint or your gdrive that you shared with AEM. See the full tutorial here:</p>
+      <p><a href="https://www.aem.live/developer/tutorial">https://www.aem.live/developer/tutorial</a></p>
+      <h2 id="this-is-another-headline-here-for-more-content">This is another headline here for more content</h2>
+      <p><a href="/"><span class="icon icon-search"></span>Default Button with Icon</a></p>
+      <p><strong><a href="/">Primary Button</a></strong></p>
+      <p><em><a href="/">Secondary Button</a></em></p>
+      <p><a href="/">Mix of</a> <strong><a href="/">B</a></strong> <a href="/">and</a> <em><a href="/">I</a></em> <a href="/">Button</a></p>
+      <p><a href="/">Partial</a> <strong><a href="/">Primary</a></strong> <a href="/">Button</a></p>
+      <p><a href="/">Partial</a> <em><a href="/">Secondary</a></em> <a href="/">Button</a></p>
+      <ol>
+        <li><a href="/">Link in…</a></li>
+        <li><a href="/">…a default content list</a></li>
+        <li>But what about a<br><a href="/">line break</a>?</li>
+      </ol>
+      <h2 id="this-is-another-headline-here-for-even-more-content">This is another headline here for even more content</h2>
+      <div class="columns">
         <div>
-          <p>Columns block</p>
-          <ul>
-            <li>One</li>
-            <li>Two</li>
-            <li>Three</li>
-          </ul>
-          <p><a href="/">Button</a></p>
+          <div>
+            <p>This is a column cell with an <a href="/">inline link</a>.</p>
+            <p><strong><a href="/">And a Button</a></strong></p>
+            <p><em><a href="/">And Another Button</a></em></p>
+            <p><a href="/"><span class="icon icon-search"></span>And an Icon Button</a></p>
+          </div>
+          <div>
+            <p>This is a column cell with a button:</p>
+            <p><a href="/">Developer Tutorial</a></p>
+          </div>
         </div>
         <div>
-          <p><strong><a href="/">Live</a></strong></p>
-          <p><em><a href="/">Preview</a></em></p>
+          <div><a href="/">Lonely Button</a></div>
+          <div>
+            <ul>
+              <li><a href="/">Links</a></li>
+              <li><a href="/">AS</a></li>
+              <li><a href="/">A</a></li>
+              <li><a href="/">List</a></li>
+              <li>But also a <a href="/">link IN a list</a></li>
+            </ul>
+          </div>
         </div>
-      </div>
-    </div>
-  </div>
-  <div>
-    <h2 id="boilerplate-highlights">Boilerplate Highlights?</h2>
-    <p>Find some of our favorite staff picks below:</p>
-    <div class="cards">
-      <div>
         <div>
-          <p><strong>Unmatched speed</strong></p>
-          <p>The fastest way to publish, create, and serve websites</p>
-        </div>
-      </div>
-      <div>
-        <div>
-          <p><strong>Content at scale</strong></p>
-          <p>Publish more content in shorter time with smaller teams</p>
-        </div>
-      </div>
-      <div>
-        <div>
-          <p><strong>Uncertainty eliminated</strong></p>
-          <p>Preview content at 100% fidelity, get predictable content velocity, and shorten project durations</p>
-        </div>
-      </div>
-      <div>
-        <div>
-          <p><strong>Widen the talent pool</strong></p>
-          <p>Authors use Microsoft Word, Excel or Google Docs and need no training</p>
-        </div>
-      </div>
-      <div>
-        <div>
-          <p><strong>The low-code way to developer productivity</strong></p>
-          <p>Say goodbye to complex APIs spanning multiple languages. Anyone with a little bit of HTML, CSS, and JS can build a site.</p>
-        </div>
-      </div>
-      <div>
-        <div>
-          <p><strong>Headless is here</strong></p>
-          <p>Go directly from Microsoft Excel or Google Sheets to the web in mere seconds. Sanitize and collect form data at extreme scale forms.</p>
-        </div>
-      </div>
-      <div>
-        <div>
-          <p><strong>Peak performance</strong></p>
-          <p>Use serverless architecture to meet any traffic need. Use the PageSpeed Insights Github action to evaluate every Pull-Request for Lighthouse Score.</p>
+          <div><strong><a href="/">Lonely Primary Button</a></strong></div>
+          <div><em><a href="/">Lonely Secondary Button</a></em></div>
         </div>
       </div>
     </div>
-    <div class="section-metadata">
-      <div>
-        <div>Style</div>
-        <div>highlight</div>
-      </div>
-      <div>
-        <div>Anchor</div>
-        <div>highlights</div>
-      </div>
-    </div>
-  </div>
+  </body>
   <script type="module">
     /* eslint-env mocha */
     import { runTests } from '@web/test-runner-mocha';
@@ -91,27 +62,37 @@
       it('decorates buttons', () => {
         const { body } = document;
         decorateButtons(body);
-        body.querySelectorAll('a').forEach((a) => {
+        body.querySelectorAll('a[href]').forEach((a) => {
+          const inList = a.closest('li');
           const p = a.closest('p');
-          const parent = a.parentElement;
-          if (p.textContent === a.textContent) {
-            expect(a.classList.contains('button')).to.be.true;
-            if (parent.nodeName === 'STRONG') {
-              // buttons wrapped in strong tag become primary buttons
-              expect(a.classList.contains('primary')).to.be.true;
-              expect(a.classList.contains('secondary')).to.be.false;
-            } else if (parent.nodeName === 'EM') {
-              // buttons wrapped in em tag become secondary buttons
-              expect(a.classList.contains('primary')).to.be.false;
-              expect(a.classList.contains('secondary')).to.be.true;
-            }
-          } else {
-            // inline as are not decorated as buttons
+          if (inList) {
+            // links in lists are not decorated as buttons
             expect(a.classList.contains('button')).to.be.false;
+          } else {
+            // all non-list links should be wrapped in a containing p
+            expect(p).to.exist;
+            if (a.href !== a.textContent) {
+              // links with matching href and text are not decorated as buttons
+              if (a.textContent !== p.textContent) {
+                // inline links are not decorated as buttons
+                expect(p.classList.contains('button-container')).to.be.false;
+                expect(a.classList.contains('button')).to.be.false;
+              } else {
+                expect(p.childNodes.length).to.equal(1);
+                expect(p.classList.contains('button-container')).to.be.true;
+                expect(a.classList.contains('button')).to.be.true;
+                // links wrapped in or containing a strong tag are decorated as primary buttons
+                if (p.querySelector('strong')) expect(a.classList.contains('primary')).to.be.true;
+                // links wrapped in or containing an em tag are decorated as secondary buttons
+                if (p.querySelector('em')) expect(a.classList.contains('secondary')).to.be.true;
+              }
+            } else {
+              expect(p.classList.contains('button-container')).to.be.false;
+              expect(a.classList.contains('button')).to.be.false;
+            }
           }
         });
       });
     });
   </script>
-</body>
 </html>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

This change works alongside #45 to add wrapping `<p>` tags to links in blocks. Because `decorateButtons()` runs _before_ `decorateBlock()` (where other block text node wrapping happens), the wrapping `<p>` tag needs to be added prior to button decoration.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

#44 adjacent

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Currently, when a link is the only content in a block cell, the wrapping `<div>` becomes the `.button-container`, resulting in an inconsistent DOM structure where some containers are `<div>`s while the rest are `<p>`s. This becomes especially obvious when trying to author a "specialized" button, like a `.primary` or `.secondary` button in a block. If the link is the only content in a block cell, the existing functionality does not recognize these styled links as meeting the criteria to be decorated as buttons.

## How Has This Been Tested?

https://decoratebuttons-test--aem-boilerplate--adobe.hlx.page/drafts/fkakatie/decorate-buttons
vs. 
https://main--aem-boilerplate--adobe.hlx.page/drafts/fkakatie/decorate-buttons

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
