### PR TITLE
test: set width and height on icon imgs

### DIFF
--- a/src/decorate.js
+++ b/src/decorate.js
@@ -60,14 +60,17 @@ export function decorateIcon(span, prefix = '', alt = '') {
   img.width = fontSize;
   img.height = fontSize;
   fetch(img.src).then((res) => {
-    res.text().then((text) => {
-      const temp = document.createElement('div');
-      temp.innerHTML = text;
-      const width = temp.querySelector('[width]');
-      if (width) img.width = width.getAttribute('width').replace(/\D/g, '');
-      const height = temp.querySelector('[height]');
-      if (height) img.height = height.getAttribute('height').replace(/\D/g, '');
-    });
+    if (res.ok) {
+      res.text().then((text) => {
+        const temp = document.createElement('div');
+        temp.innerHTML = text;
+        const svg = temp.querySelector('svg');
+        const w = svg.width.baseVal.value;
+        if (w) img.width = w;
+        const h = svg.height.baseVal.value;
+        if (h) img.width = h;
+      });
+    }
   });
   span.append(img);
 }

--- a/src/decorate.js
+++ b/src/decorate.js
@@ -56,6 +56,19 @@ export function decorateIcon(span, prefix = '', alt = '') {
   img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
   img.alt = alt;
   img.loading = 'lazy';
+  const fontSize = window.getComputedStyle(span).fontSize.replace(/\D/g, '');
+  img.width = fontSize;
+  img.height = fontSize;
+  fetch(img.src).then((res) => {
+    res.text().then((text) => {
+      const temp = document.createElement('div');
+      temp.innerHTML = text;
+      const width = temp.querySelector('[width]');
+      if (width) img.width = width.getAttribute('width').replace(/\D/g, '');
+      const height = temp.querySelector('[height]');
+      if (height) img.height = height.getAttribute('height').replace(/\D/g, '');
+    });
+  });
   span.append(img);
 }
 

--- a/src/decorate.js
+++ b/src/decorate.js
@@ -59,19 +59,6 @@ export function decorateIcon(span, prefix = '', alt = '') {
   const fontSize = window.getComputedStyle(span).fontSize.replace(/\D/g, '');
   img.width = fontSize;
   img.height = fontSize;
-  fetch(img.src).then((res) => {
-    if (res.ok) {
-      res.text().then((text) => {
-        const temp = document.createElement('div');
-        temp.innerHTML = text;
-        const svg = temp.querySelector('svg');
-        const w = svg.width.baseVal.value;
-        if (w) img.width = w;
-        const h = svg.height.baseVal.value;
-        if (h) img.width = h;
-      });
-    }
-  });
   span.append(img);
 }
 

--- a/src/decorate.js
+++ b/src/decorate.js
@@ -56,9 +56,8 @@ export function decorateIcon(span, prefix = '', alt = '') {
   img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
   img.alt = alt;
   img.loading = 'lazy';
-  const fontSize = window.getComputedStyle(span).fontSize.replace(/\D/g, '');
-  img.width = fontSize;
-  img.height = fontSize;
+  img.width = 16;
+  img.height = 16;
   span.append(img);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
PageSpeed Insights diagnostics recommends to "[s]et an explicit width and height on image elements to reduce layout shifts and improve CLS." 

Currently, the `decorateIcon` function creates an `img` tag for SVGs _without_ setting an explicit width or height. 

Proposal to set an explicit width and height based on the *font size* of the containing element (the `span`).

## Test URLs

- Before: https://main--moneyedge--aemsites.hlx.page/napkin-finance
- After: https://test-icon-size--moneyedge--aemsites.hlx.page/napkin-finance

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
