### PR TITLE
feat(setup): better RUM error logging

### DIFF
--- a/src/setup.js
+++ b/src/setup.js
@@ -43,13 +43,14 @@ export function init() {
 
   window.addEventListener('load', () => sampleRUM('load'));
 
-  window.addEventListener('unhandledrejection', (event) => {
-    /* c8 ignore next */
-    sampleRUM('error', { source: event.reason.sourceURL, target: event.reason.line });
-  });
-
-  window.addEventListener('error', (event) => {
-    /* c8 ignore next */
-    sampleRUM('error', { source: event.filename, target: event.lineno });
+  ['error', 'unhandledrejection'].forEach((event) => {
+    window.addEventListener(event, ({ reason, error }) => {
+      /* c8 ignore next 5 */
+      const source = (reason || error).stack.split('\n')
+        .filter((line) => line.match(/https?:\/\//)).shift()
+        .replace(/at ([^ ]+) \((.+)\)/, '$1@$2');
+      const target = (reason || error).toString();
+      sampleRUM('error', { source, target });
+    });
   });
 }


### PR DESCRIPTION
unifies the error format for JS errors and unhandled promises across browsers 
- `source`: the function, script, line, and column where the error/rejection happened 
- `target`: the error/rejection message

In the screenshots above, the first pair of messages is from an rejected promise, the second from an interactively triggered error.

##### Chrome
<img width="853" alt="Screenshot 2024-04-18 at 11 18 36" src="https://github.com/adobe/aem-lib/assets/39613/036454eb-c73a-41a1-b786-42aabdd65b03">

##### Safari
<img width="853" alt="Screenshot 2024-04-18 at 11 18 44" src="https://github.com/adobe/aem-lib/assets/39613/5708400c-6b80-4234-b38e-d662c0af3f0f">

#### Firefox
<img width="853" alt="Screenshot 2024-04-18 at 11 18 56" src="https://github.com/adobe/aem-lib/assets/39613/775e58ac-68cb-4341-bfb2-7dbc24908c36">
