### PR TITLE
feat: repair release process

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -3,8 +3,7 @@
     "github>adobe/helix-shared"
   ],
   "baseBranches": [
-    "main",
-    "2.x"
+    "main"
   ],
   "packageRules": [
     {

--- a/publish.sh
+++ b/publish.sh
@@ -8,12 +8,6 @@ TYPE=$2 # can be major, minor, patch
 VERSION_DASH=${VERSION//./-}
 BRANCH=update-lib-aem-$TYPE-$VERSION_DASH
 
-# if the version is 2.0.0 or greater, exit gracefully now
-if [[ $VERSION == 2.* ]]; then
-  echo "Version $VERSION is 2.0.0 or greater, exiting gracefully"
-  exit 0
-fi
-
 cd ..
 echo "Using gh version: $(gh --version)"
 gh repo clone $ORG/$REPO


### PR DESCRIPTION
Restoring release process.

Current aem-lib depends on `@adobe/helix-rum-js` version less than 2.0.0.
#76 handles the migration to post 2.0.0 version.
aem-lib version is now 2.x which is independent from the rum version.