### PR TITLE
fix: use latest rum-js released version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.5.0",
       "license": "Apache License 2.0",
       "dependencies": {
-        "@adobe/helix-rum-js": "https://github.com/adobe/helix-rum-js#enhancer-load"
+        "@adobe/helix-rum-js": "2.2.0"
       },
       "devDependencies": {
         "@babel/core": "7.25.2",
@@ -69,8 +69,9 @@
       }
     },
     "node_modules/@adobe/helix-rum-js": {
-      "version": "2.1.4",
-      "resolved": "git+ssh://git@github.com/adobe/helix-rum-js.git#32fc67352a50267791a71d2db8b549e3c8d56950"
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@adobe/helix-rum-js/-/helix-rum-js-2.2.0.tgz",
+      "integrity": "sha512-X/+Ol62T56Vdl7JfZVo4SwSnLqAyg2ruuaCIXRvGDZUv+0G8oi60g4tWjG5XXQefsr7sEg3guOYNjG0byPVqiA=="
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "stylelint-config-standard": "36.0.1"
   },
   "dependencies": {
-    "@adobe/helix-rum-js": "https://github.com/adobe/helix-rum-js#enhancer-load"
+    "@adobe/helix-rum-js": "2.2.0"
   }
 }


### PR DESCRIPTION
rum-js dep is still map to a dev branch. Moving back to latest released version.