### PR TITLE
feat: predefine loading of sampleRUM.enhance()

### DIFF
--- a/src/block-loader.js
+++ b/src/block-loader.js
@@ -10,6 +10,7 @@
  * governing permissions and limitations under the License.
  */
 
+import { sampleRUM } from '@adobe/helix-rum-js';
 import { loadCSS, wrapTextNodes } from './dom-utils.js';
 
 /**
@@ -177,5 +178,8 @@ export async function loadSections(element) {
   for (let i = 0; i < sections.length; i += 1) {
     // eslint-disable-next-line no-await-in-loop
     await loadSection(sections[i]);
+    if (i === 0 && sampleRUM.enhance) {
+      sampleRUM.enhance();
+    }
   }
 }

--- a/test/block-loader/loadBlocks.withrum.test.html
+++ b/test/block-loader/loadBlocks.withrum.test.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <main>
+      <div class="section">
+        <div class="wrapper">
+          <div class="block block1" data-block-name="simpleblock"><p>This is the first block</p></div>
+        </div>
+        <div class="wrapper">
+          <div class="block block2" data-block-name="asyncblock"><p>This is the second block</p></div>
+        </div>
+      </div>
+      <div class="section">
+        <div class="wrapper">
+          <div class="block block3" data-block-name="simpleblock"><p>This is the third block</p></div>
+        </div>
+        <div class="wrapper">
+          <div class="block block4" data-block-name="asyncblock"><p>This is the fourth block</p></div>
+        </div>
+      </div>
+    </main>
+    
+    <script type="module">
+      /* eslint-env mocha */
+      import { runTests } from '@web/test-runner-mocha';
+      import { expect } from '@esm-bundle/chai';
+      import { sampleRUM } from '@adobe/helix-rum-js';
+      import { loadSections } from '../../src/block-loader.js';
+
+      window.hlx = {};
+
+      runTests(() => {
+        beforeEach(() => {
+          const usp = new URLSearchParams(window.location.search);
+          usp.append('rum', 'on');
+          window.history.replaceState({}, '', `${window.location.pathname}?${usp.toString()}`);
+        });
+
+        afterEach(() => {
+          const usp = new URLSearchParams(window.location.search);
+          usp.delete('rum');
+          window.history.replaceState({}, '', `${window.location.pathname}?${usp.toString()}`);
+          // eslint-disable-next-line no-underscore-dangle
+          window.hlx.rum = undefined;
+
+          const enhancer = document.querySelector('script[src*="rum-enhancer"]');
+          if (enhancer) {
+            enhancer.remove();
+          }
+        });
+
+        it('loadBlocks - loads all blocks', async () => {
+          window.hlx.codeBasePath = '/test/fixtures';
+          sampleRUM();
+
+          await loadSections(document.querySelector('main'));
+
+          // loadSections should have run "sampleRUM.enhance()"
+          expect(document.querySelector('script[src*="rum-enhancer"]')).to.exist;
+        });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
In the current setup, the project requires to call `sampleRUM.enhance()` in order for the enhancer to get loaded. If the line disappears or is forgotten, enhancer is never loaded. Moving call in the lib would solve that problem. 

Compared to current implementation, this moves the enhancer loading slightly later (after async font loading) which should not change anything.