### PR TITLE
Do not repeat processing of icon if it exists.

### DIFF
--- a/src/decorate.js
+++ b/src/decorate.js
@@ -50,6 +50,7 @@ export function decorateButtons(element) {
  * @param {string} [alt] alt text to be added to icon
  */
 export function decorateIcon(span, prefix = '', alt = '') {
+  if (span.querySelector('img')) return;
   const iconName = Array.from(span.classList).find((c) => c.startsWith('icon-')).substring(5);
   const img = document.createElement('img');
   img.dataset.iconName = iconName;

--- a/test/decorate/decorateIcon.test.html
+++ b/test/decorate/decorateIcon.test.html
@@ -1,39 +1,64 @@
 <!DOCTYPE html>
 <html lang="en">
 <body>
-  <script type="module">
-    /* eslint-env mocha */
-    import { runTests } from '@web/test-runner-mocha';
-    import { expect } from '@esm-bundle/chai';
-    import { decorateIcon } from '../../src/decorate.js';
+<script type="module">
+  /* eslint-env mocha */
+  import { runTests } from '@web/test-runner-mocha';
+  import { expect } from '@esm-bundle/chai';
+  import { decorateIcon } from '../../src/decorate.js';
+  import { decorateIcons } from '../../src/index.js';
 
-    window.hlx = {};
+  window.hlx = {};
 
-    runTests(() => {
-      it('decorates icons with alt text', async () => {
-        window.hlx.codeBasePath = '/test/fixtures';
+  runTests(() => {
+    beforeEach(() => {
+      document.body.querySelectorAll('span').forEach((el) => el.remove());
+    });
 
-        const iconA = document.createElement('span');
-        iconA.className = 'icon icon-a';
-        decorateIcon(iconA, '', 'icon a alt text');
+    it('decorates icons with alt text', async () => {
+      window.hlx.codeBasePath = '/test/fixtures';
 
-        const iconB = document.createElement('span');
-        iconB.className = 'icon icon-b';
-        decorateIcon(iconB);
+      const iconA = document.createElement('span');
+      iconA.className = 'icon icon-a';
+      decorateIcon(iconA, '', 'icon a alt text');
 
-        document.body.prepend(iconA, iconB);
+      const iconB = document.createElement('span');
+      iconB.className = 'icon icon-b';
+      decorateIcon(iconB);
 
-        const icons = document.querySelectorAll('.icon');
-        icons.forEach((icon) => {
-          expect(icon.firstElementChild.alt).to.exist;
-          if (icon === iconA) {
-            expect(icon.firstElementChild.alt).to.be.equal('icon a alt text');
-          } else if (icon === iconB) {
-            expect(icon.firstElementChild.alt).to.be.equal('');
-          }
-        });
+      document.body.prepend(iconA, iconB);
+
+      const icons = document.querySelectorAll('.icon');
+      icons.forEach((icon) => {
+        expect(icon.firstElementChild.alt).to.exist;
+        if (icon === iconA) {
+          expect(icon.firstElementChild.alt).to.be.equal('icon a alt text');
+        } else if (icon === iconB) {
+          expect(icon.firstElementChild.alt).to.be.equal('');
+        }
       });
     });
-  </script>
+
+    it('does not process icon if img exists', async () => {
+      window.hlx.codeBasePath = '/test/fixtures';
+      const iconA = document.createElement('span');
+      iconA.className = 'icon icon-a';
+      decorateIcon(iconA, '', 'icon a alt text');
+
+      const iconB = document.createElement('span');
+      iconB.className = 'icon icon-b';
+      decorateIcon(iconB);
+
+      document.body.prepend(iconA, iconB);
+      decorateIcons(document.body);
+
+      const icons = document.querySelectorAll('.icon');
+      icons.forEach((icon) => {
+        const img = icon.querySelectorAll('img');
+        expect(img.length).to.be.equal(1);
+      });
+    });
+  });
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Description

If there is exists an image tag in icon ref, skip processing that icon.

## Related Issue

Fix: #128 

## Motivation and Context

Prevent accidental repeated processing of elements for icons.

## How Has This Been Tested?

Added unit tests.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
