### PR TITLE
feat(placeholders): enhance fetchPlaceholders to support metadata ove…

### DIFF
--- a/dist/aem.js
+++ b/dist/aem.js
@@ -506,27 +506,53 @@ function decorateSections(main) {
  */
 // eslint-disable-next-line import/prefer-default-export
 async function fetchPlaceholders(prefix = 'default') {
+  const overrides = getMetadata('placeholders') || getMetadata('root')?.replace(/\/$/, '/placeholders.json') || '';
+  const [fallback, override] = overrides.split('\n');
   window.placeholders = window.placeholders || {};
+
   if (!window.placeholders[prefix]) {
     window.placeholders[prefix] = new Promise((resolve) => {
-      fetch(`${prefix === 'default' ? '' : prefix}/placeholders.json`)
-        .then((resp) => {
+      const url = fallback || `${prefix === 'default' ? '' : prefix}/placeholders.json`;
+      Promise.all([fetch(url), override ? fetch(override) : Promise.resolve()])
+        // get json from sources
+        .then(async ([resp, oResp]) => {
           if (resp.ok) {
-            return resp.json();
+            if (oResp?.ok) {
+              return Promise.all([resp.json(), await oResp.json()]);
+            }
+            return Promise.all([resp.json(), {}]);
           }
-          return {};
+          return [{}];
         })
-        .then((json) => {
+        // process json from sources
+        .then(([json, oJson]) => {
           const placeholders = {};
-          json.data
-            .filter((placeholder) => placeholder.Key)
-            .forEach((placeholder) => {
-              placeholders[toCamelCase(placeholder.Key)] = placeholder.Text;
-            });
+
+          const allKeys = new Set([
+            ...(json.data?.map(({ Key }) => Key) || []),
+            ...(oJson?.data?.map(({ Key }) => Key) || []),
+          ]);
+
+          allKeys.forEach((Key) => {
+            if (!Key) return;
+            const keys = Key.split('.');
+            const originalValue = json.data?.find((item) => item.Key === Key)?.Value;
+            const overrideValue = oJson?.data?.find((item) => item.Key === Key)?.Value;
+            const finalValue = overrideValue ?? originalValue;
+            const lastKey = keys.pop();
+            const target = keys.reduce((obj, key) => {
+              obj[key] = obj[key] || {};
+              return obj[key];
+            }, placeholders);
+            target[lastKey] = finalValue;
+          });
+
           window.placeholders[prefix] = placeholders;
-          resolve(window.placeholders[prefix]);
+          resolve(placeholders);
         })
-        .catch(() => {
+        .catch((error) => {
+          // eslint-disable-next-line no-console
+          console.error('error loading placeholders', error);
           // error loading placeholders
           window.placeholders[prefix] = {};
           resolve(window.placeholders[prefix]);

--- a/dist/aem.js
+++ b/dist/aem.js
@@ -506,53 +506,27 @@ function decorateSections(main) {
  */
 // eslint-disable-next-line import/prefer-default-export
 async function fetchPlaceholders(prefix = 'default') {
-  const overrides = getMetadata('placeholders') || getMetadata('root')?.replace(/\/$/, '/placeholders.json') || '';
-  const [fallback, override] = overrides.split('\n');
   window.placeholders = window.placeholders || {};
-
   if (!window.placeholders[prefix]) {
     window.placeholders[prefix] = new Promise((resolve) => {
-      const url = fallback || `${prefix === 'default' ? '' : prefix}/placeholders.json`;
-      Promise.all([fetch(url), override ? fetch(override) : Promise.resolve()])
-        // get json from sources
-        .then(async ([resp, oResp]) => {
+      fetch(`${prefix === 'default' ? '' : prefix}/placeholders.json`)
+        .then((resp) => {
           if (resp.ok) {
-            if (oResp?.ok) {
-              return Promise.all([resp.json(), await oResp.json()]);
-            }
-            return Promise.all([resp.json(), {}]);
+            return resp.json();
           }
-          return [{}];
+          return {};
         })
-        // process json from sources
-        .then(([json, oJson]) => {
+        .then((json) => {
           const placeholders = {};
-
-          const allKeys = new Set([
-            ...(json.data?.map(({ Key }) => Key) || []),
-            ...(oJson?.data?.map(({ Key }) => Key) || []),
-          ]);
-
-          allKeys.forEach((Key) => {
-            if (!Key) return;
-            const keys = Key.split('.');
-            const originalValue = json.data?.find((item) => item.Key === Key)?.Value;
-            const overrideValue = oJson?.data?.find((item) => item.Key === Key)?.Value;
-            const finalValue = overrideValue ?? originalValue;
-            const lastKey = keys.pop();
-            const target = keys.reduce((obj, key) => {
-              obj[key] = obj[key] || {};
-              return obj[key];
-            }, placeholders);
-            target[lastKey] = finalValue;
-          });
-
+          json.data
+            .filter((placeholder) => placeholder.Key)
+            .forEach((placeholder) => {
+              placeholders[toCamelCase(placeholder.Key)] = placeholder.Text;
+            });
           window.placeholders[prefix] = placeholders;
-          resolve(placeholders);
+          resolve(window.placeholders[prefix]);
         })
-        .catch((error) => {
-          // eslint-disable-next-line no-console
-          console.error('error loading placeholders', error);
+        .catch(() => {
           // error loading placeholders
           window.placeholders[prefix] = {};
           resolve(window.placeholders[prefix]);

--- a/src/placeholders.js
+++ b/src/placeholders.js
@@ -20,14 +20,13 @@ import { getMetadata } from './dom-utils.js';
 // eslint-disable-next-line import/prefer-default-export
 export async function fetchPlaceholders(prefix = 'default') {
   const root = getMetadata('root')?.replace(/\/$/, '') || (prefix === 'default' ? '' : prefix);
-  const [override, fallback] = getMetadata('placeholders')?.split('\n') || [];
+  const [override, merge] = getMetadata('placeholders')?.split('\n') || [];
   const url = override || `${root}/placeholders.json`;
   window.placeholders = window.placeholders || {};
 
   if (!window.placeholders[prefix]) {
     window.placeholders[prefix] = new Promise((resolve) => {
-      // const url = fallback || `${prefix === 'default' ? '' : prefix}/placeholders.json`;
-      Promise.all([fetch(url), fallback ? fetch(fallback) : Promise.resolve()])
+      Promise.all([fetch(url), merge ? fetch(merge) : Promise.resolve()])
         // get json from sources
         .then(async ([resp, oResp]) => {
           if (resp.ok) {
@@ -39,19 +38,19 @@ export async function fetchPlaceholders(prefix = 'default') {
           return [{}];
         })
         // process json from sources
-        .then(([json, oJson]) => {
+        .then(([json, mJson]) => {
           const placeholders = {};
 
           const allKeys = new Set([
             ...(json.data?.map(({ Key }) => Key) || []),
-            ...(oJson?.data?.map(({ Key }) => Key) || []),
+            ...(mJson?.data?.map(({ Key }) => Key) || []),
           ]);
 
           allKeys.forEach((Key) => {
             if (!Key) return;
             const keys = Key.split('.');
             const originalValue = json.data?.find((item) => item.Key === Key)?.Text;
-            const overrideValue = oJson?.data?.find((item) => item.Key === Key)?.Text;
+            const overrideValue = mJson?.data?.find((item) => item.Key === Key)?.Text;
             const finalValue = overrideValue ?? originalValue;
             const lastKey = keys.pop();
             const target = keys.reduce((obj, key) => {

--- a/src/placeholders.js
+++ b/src/placeholders.js
@@ -19,14 +19,15 @@ import { getMetadata } from './dom-utils.js';
  */
 // eslint-disable-next-line import/prefer-default-export
 export async function fetchPlaceholders(prefix = 'default') {
-  const overrides = getMetadata('placeholders') || getMetadata('root')?.replace(/\/$/, '/placeholders.json') || '';
-  const [fallback, override] = overrides.split('\n');
+  const root = getMetadata('root')?.replace(/\/$/, '') || (prefix === 'default' ? '' : prefix);
+  const [override, fallback] = getMetadata('placeholders')?.split('\n') || [];
+  const url = override || `${root}/placeholders.json`;
   window.placeholders = window.placeholders || {};
 
   if (!window.placeholders[prefix]) {
     window.placeholders[prefix] = new Promise((resolve) => {
-      const url = fallback || `${prefix === 'default' ? '' : prefix}/placeholders.json`;
-      Promise.all([fetch(url), override ? fetch(override) : Promise.resolve()])
+      // const url = fallback || `${prefix === 'default' ? '' : prefix}/placeholders.json`;
+      Promise.all([fetch(url), fallback ? fetch(fallback) : Promise.resolve()])
         // get json from sources
         .then(async ([resp, oResp]) => {
           if (resp.ok) {

--- a/src/placeholders.js
+++ b/src/placeholders.js
@@ -50,8 +50,8 @@ export async function fetchPlaceholders(prefix = 'default') {
           allKeys.forEach((Key) => {
             if (!Key) return;
             const keys = Key.split('.');
-            const originalValue = json.data?.find((item) => item.Key === Key)?.Value;
-            const overrideValue = oJson?.data?.find((item) => item.Key === Key)?.Value;
+            const originalValue = json.data?.find((item) => item.Key === Key)?.Text;
+            const overrideValue = oJson?.data?.find((item) => item.Key === Key)?.Text;
             const finalValue = overrideValue ?? originalValue;
             const lastKey = keys.pop();
             const target = keys.reduce((obj, key) => {

--- a/test/fixtures/es/placeholders.json
+++ b/test/fixtures/es/placeholders.json
@@ -5,14 +5,14 @@
     "data": [
       {
         "Key": "Key1",
-        "Value": "Valor1"
+        "Text": "Valor1"
       }, {
         "Key": "Key With Space",
-        "Value": "Valor con espacio"
+        "Text": "Valor con espacio"
       },
       {
         "Key": "Key.With.Dot",
-        "Value": "Valor con punto"
+        "Text": "Valor con punto"
       }
     ]
   }

--- a/test/fixtures/es/placeholders.json
+++ b/test/fixtures/es/placeholders.json
@@ -1,0 +1,18 @@
+{
+    "total": 3,
+    "offset": 0,
+    "limit": 3,
+    "data": [
+      {
+        "Key": "Key1",
+        "Value": "Valor1"
+      }, {
+        "Key": "Key With Space",
+        "Value": "Valor con espacio"
+      },
+      {
+        "Key": "Key.With.Dot",
+        "Value": "Valor con punto"
+      }
+    ]
+  }

--- a/test/fixtures/placeholders.json
+++ b/test/fixtures/placeholders.json
@@ -1,14 +1,18 @@
 {
-  "total": 2,
+  "total": 3,
   "offset": 0,
-  "limit": 2,
+  "limit": 3,
   "data": [
     {
       "Key": "Key1",
-      "Text": "Value1"
+      "Value": "Value1"
     }, {
       "Key": "Key With Space",
-      "Text": "Key With Space Value"
+      "Value": "Key With Space Value"
+    },
+    {
+      "Key": "Key.With.Dot",
+      "Value": "Key With Dot Value"
     }
   ]
 }

--- a/test/fixtures/placeholders.json
+++ b/test/fixtures/placeholders.json
@@ -5,14 +5,14 @@
   "data": [
     {
       "Key": "Key1",
-      "Value": "Value1"
+      "Text": "Value1"
     }, {
       "Key": "Key With Space",
-      "Value": "Key With Space Value"
+      "Text": "Key With Space Value"
     },
     {
       "Key": "Key.With.Dot",
-      "Value": "Key With Dot Value"
+      "Text": "Key With Dot Value"
     }
   ]
 }

--- a/test/fixtures/placeholders2.json
+++ b/test/fixtures/placeholders2.json
@@ -1,0 +1,15 @@
+{
+  "total": 2,
+  "offset": 0,
+  "limit": 2,
+  "data": [
+    {
+      "Key": "Key2",
+      "Value": "Value2"
+    }, 
+    {
+      "Key": "Key.With.Dot",
+      "Value": "Key With Dot Value 2"
+    }
+  ]
+}

--- a/test/fixtures/placeholders2.json
+++ b/test/fixtures/placeholders2.json
@@ -5,11 +5,11 @@
   "data": [
     {
       "Key": "Key2",
-      "Value": "Value2"
+      "Text": "Value2"
     }, 
     {
       "Key": "Key.With.Dot",
-      "Value": "Key With Dot Value 2"
+      "Text": "Key With Dot Value 2"
     }
   ]
 }

--- a/test/placeholders/fetchPlaceholders.test.html
+++ b/test/placeholders/fetchPlaceholders.test.html
@@ -15,6 +15,10 @@
       import { fetchPlaceholders } from '../../src/placeholders.js';
 
       runTests(() => {
+        beforeEach(() => {
+          window.placeholders = {};
+        });
+
         it('fetchPlaceholders - no placeholder file at root', async () => {
           try {
             const placeholders = await fetchPlaceholders();
@@ -26,9 +30,60 @@
 
         it('fetchPlaceholders - placeholder file in fixtures folder', async () => {
           const placeholders = await fetchPlaceholders('../fixtures');
-          expect(placeholders.key1).to.equal('Value1');
-          expect(placeholders.keyWithSpace).to.equal('Key With Space Value');
+          expect(placeholders.Key1).to.equal('Value1');
+          expect(placeholders['Key With Space']).to.equal('Key With Space Value');
+          expect(placeholders.Key.With.Dot).to.equal('Key With Dot Value');
           expect(placeholders.unknown).to.be.undefined;
+        });
+
+        it('fetchPlaceholders - override placeholders path with metadata', async () => {
+          // Add meta tag for this test only
+          const meta = document.createElement('meta');
+          meta.setAttribute('name', 'placeholders');
+          meta.setAttribute('content', '../fixtures/placeholders2.json');
+          document.head.appendChild(meta);
+
+          const placeholders = await fetchPlaceholders();
+          expect(placeholders.Key1).to.be.undefined;
+          expect(placeholders['Key With Space']).to.be.undefined;
+          expect(placeholders.Key2).to.equal('Value2');
+          expect(placeholders.Key.With.Dot).to.equal('Key With Dot Value 2');
+
+          // Clean up after test
+          meta.remove();
+        });
+
+        it('fetchPlaceholders - override placeholders path with metadata with fallback', async () => {
+          // Add meta tag for this test only
+          const meta = document.createElement('meta');
+          meta.setAttribute('name', 'placeholders');
+          meta.setAttribute('content', '../fixtures/placeholders.json\n../fixtures/placeholders2.json');
+          document.head.appendChild(meta);
+
+          const placeholders = await fetchPlaceholders();
+          expect(placeholders.Key1).to.equal('Value1');
+          expect(placeholders.Key2).to.equal('Value2');
+          expect(placeholders['Key With Space']).to.equal('Key With Space Value');
+          expect(placeholders.Key.With.Dot).to.equal('Key With Dot Value 2');
+
+          // Clean up after test
+          meta.remove();
+        });
+
+        it('fetchPlaceholders - override placeholders path with root metadata', async () => {
+          // Add meta tag for this test only
+          const meta = document.createElement('meta');
+          meta.setAttribute('name', 'root');
+          meta.setAttribute('content', '../fixtures/es/');
+          document.head.appendChild(meta);
+
+          const placeholders = await fetchPlaceholders();
+          expect(placeholders.Key1).to.equal('Valor1');
+          expect(placeholders['Key With Space']).to.equal('Valor con espacio');
+          expect(placeholders.Key.With.Dot).to.equal('Valor con punto');
+
+          // Clean up after test
+          meta.remove();
         });
       });
     </script>


### PR DESCRIPTION
## Description

This update enhances the `fetchPlaceholders` function in `aem.js` to support more structured and flexible placeholder definitions. It introduces dot notation key access, enabling a one-to-one mapping with components like Commerce Drop-ins. These improvements streamline localization, experimentation, and integration use cases by reducing the need for manual key transformation or large variant spreadsheets.

## Related Issue

TBD

## Motivation and Context

This change was driven by three key goals:

### Localization
Support for loading placeholders from locale-specific root folders, making it easier to manage multilingual/multisite storefronts.

![image](https://github.com/user-attachments/assets/1a73102a-cd6f-4f1d-a244-7696f68c59bf)

### A/B Experimentation 

Easier management of variant-specific labels without complex spreadsheets.

![image](https://github.com/user-attachments/assets/7aeae84c-de26-47e6-99f0-f73958eb0aee)

**placeholders-variant.xlsx**
<img width="1070" alt="image" src="https://github.com/user-attachments/assets/604ba6e9-0c2f-4627-ae39-6e86600a8e22" />

### Commerce Drop-ins Integration

Dot notation enables clean mapping between structured placeholders and component props.

![image](https://github.com/user-attachments/assets/31a1532e-5402-466d-910d-ec7337df6c73)

```js
// use a placeholder in a Block
const labels = await fetchPlaceholders();
// existing
elem.innerText = labels['my-flat-label'];
// but also (new)
elem.innerText = labels.foo.bar;

// apply placeholders to drop-in
await initializeDropin(async () => {
setFetchGraphQlHeaders(await getHeaders('cart'));

const labels = await fetchPlaceholders();
const langDefinitions = {
  default: {
    ...labels,
  },
};

return initializers.mountImmediately(initialize, { langDefinitions });
})();
```

## How Has This Been Tested?

This update is already being used in the Commerce Boilerplate to support multiple locales and storefronts. It's also been validated in Commerce Drop-in environments with placeholder overrides for A/B testing.

- standard: https://multistore--aem-boilerplate-commerce--anthoula.aem.page/
- localization: https://multistore--aem-boilerplate-commerce--anthoula.aem.page/drafts/multistore/en/
- overrides: https://multistore--aem-boilerplate-commerce--anthoula.aem.page/drafts/multistore/en_ca/

## Screenshots (if appropriate):

N/A

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
