### PR TITLE
Print error instead of log message in DevTools console when exception is thrown

### DIFF
--- a/src/block-loader.js
+++ b/src/block-loader.js
@@ -64,7 +64,7 @@ export async function loadBlock(block) {
             }
           } catch (error) {
             // eslint-disable-next-line no-console
-            console.log(`failed to load module for ${blockName}`, error);
+            console.error(`failed to load module for ${blockName}`, error);
           }
           resolve();
         })();
@@ -72,7 +72,7 @@ export async function loadBlock(block) {
       await Promise.all([cssLoaded, decorationComplete]);
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.log(`failed to load block ${blockName}`, error);
+      console.error(`failed to load block ${blockName}`, error);
     }
     block.dataset.blockStatus = 'loaded';
   }


### PR DESCRIPTION
When `loadBlock()` throws an exception, in DevTools console regular log message is used instead of error. The change introduced in this PR uses `console.error` to print error.

<!--- Provide a general summary of your changes in the Title above -->

## Description

- `console.log` calls changed to `console.error` in `catch` statement

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

When `loadBlock()` throws an error, in DevTools console it's not visible as an actual error, but it is printed as a regular message. Thus, it is not immediately obvious that something happened, especially when there are many other entries in messages log:

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The change was tested manually.

**Before change:**

<img width="913" alt="Screenshot 2025-06-03 at 13 42 03" src="https://github.com/user-attachments/assets/e0d89781-900f-4981-9efb-63bf29af708d" />


**After change:**


<img width="907" alt="Screenshot 2025-06-03 at 17 52 45" src="https://github.com/user-attachments/assets/61b60663-b507-470a-a856-90f369d6acad" />

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
