### PR TITLE
fix(block-loader): replace existing header/footer block instead of appending

### DIFF
--- a/src/block-loader.js
+++ b/src/block-loader.js
@@ -114,7 +114,12 @@ export function decorateBlocks(main) {
  */
 export async function loadHeader(header) {
   const headerBlock = buildBlock('header', '');
-  header.append(headerBlock);
+  const existingHeaderBlock = header.querySelector(':scope > .header');
+  if (existingHeaderBlock) {
+    existingHeaderBlock.replaceWith(headerBlock);
+  } else {
+    header.append(headerBlock);
+  }
   decorateBlock(headerBlock);
   return loadBlock(headerBlock);
 }
@@ -126,7 +131,12 @@ export async function loadHeader(header) {
  */
 export async function loadFooter(footer) {
   const footerBlock = buildBlock('footer', '');
-  footer.append(footerBlock);
+  const existingFooterBlock = footer.querySelector(':scope > .footer');
+  if (existingFooterBlock) {
+    existingFooterBlock.replaceWith(footerBlock);
+  } else {
+    footer.append(footerBlock);
+  }
   decorateBlock(footerBlock);
   return loadBlock(footerBlock);
 }

--- a/test/block-loader/loadFooter.duplicate.test.html
+++ b/test/block-loader/loadFooter.duplicate.test.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <footer></footer>
+
+    <script type="module">
+      /* eslint-env mocha */
+      import { runTests } from '@web/test-runner-mocha';
+      import { expect } from '@esm-bundle/chai';
+      import { loadFooter } from '../../src/block-loader.js';
+
+      window.hlx = {};
+
+      runTests(() => {
+        it('loadFooter - calling twice does not duplicate the footer block', async () => {
+          window.hlx.codeBasePath = '/test/fixtures';
+          const footer = document.querySelector('footer');
+          footer.innerHTML = '';
+
+          await loadFooter(footer);
+          await loadFooter(footer);
+
+          const footerBlocks = footer.querySelectorAll(':scope > .footer');
+          expect(footerBlocks.length).to.equal(1);
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/test/block-loader/loadHeader.duplicate.test.html
+++ b/test/block-loader/loadHeader.duplicate.test.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <header></header>
+
+    <script type="module">
+      /* eslint-env mocha */
+      import { runTests } from '@web/test-runner-mocha';
+      import { expect } from '@esm-bundle/chai';
+      import { loadHeader } from '../../src/block-loader.js';
+
+      window.hlx = {};
+
+      runTests(() => {
+        it('loadHeader - calling twice does not duplicate the header block', async () => {
+          window.hlx.codeBasePath = '/test/fixtures';
+          const header = document.querySelector('header');
+          header.innerHTML = '';
+
+          await loadHeader(header);
+          await loadHeader(header);
+
+          const headerBlocks = header.querySelectorAll(':scope > .header');
+          expect(headerBlocks.length).to.equal(1);
+        });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- `loadHeader`/`loadFooter` always appended a new block, so if they ran more than once (e.g. with EW/Quick Edit) the header/footer element ended up with duplicate blocks
- Now checks for an existing `.header`/`.footer` block as a direct child and replaces it in place instead of blindly appending

Fixes #236

## Test plan
- [x] `npm run lint`
- [x] `npm test` (added tests asserting a second `loadHeader`/`loadFooter` call does not duplicate the block)

Co-Authored-By: Claude <noreply@anthropic.com>