### PR TITLE
fix: treat blockquote as a valid wrapper in wrapTextNodes

### DIFF
--- a/src/dom-utils.js
+++ b/src/dom-utils.js
@@ -136,6 +136,7 @@ export function wrapTextNodes(block) {
     'UL', 'OL',
     'PICTURE',
     'TABLE',
+    'BLOCKQUOTE',
     'H1', 'H2', 'H3', 'H4', 'H5', 'H6',
   ];
 

--- a/test/dom-utils/wrapTextNodes.test.html
+++ b/test/dom-utils/wrapTextNodes.test.html
@@ -110,6 +110,16 @@
           <div></div>
         </div>
       </div>
+      <div class="blockquotes original">
+        <div>
+          <div><blockquote>a blockquote will not be wrapped</blockquote></div>
+        </div>
+      </div>
+      <div class="blockquotes expected">
+        <div>
+          <div><blockquote>a blockquote will not be wrapped</blockquote></div>
+        </div>
+      </div>
     </div>
   </main>
   <script type="module">
@@ -164,6 +174,14 @@
       it('does not modify empty cells', () => {
         const original = document.querySelector('.original.empty-cells');
         const expected = document.querySelector('.expected.empty-cells');
+        wrapTextNodes(original);
+
+        expect(original.innerHTML).to.equal(expected.innerHTML);
+      });
+
+      it('does not modify blockquotes', () => {
+        const original = document.querySelector('.original.blockquotes');
+        const expected = document.querySelector('.expected.blockquotes');
         wrapTextNodes(original);
 
         expect(original.innerHTML).to.equal(expected.innerHTML);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Blockquotes are block-level content and shouldn't be re-wrapped in a paragraph, same as headings, tables, and lists.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
